### PR TITLE
Filter bottle.BaseResponse, which is raised as an exception

### DIFF
--- a/rollbar/contrib/bottle/__init__.py
+++ b/rollbar/contrib/bottle/__init__.py
@@ -16,7 +16,8 @@ class RollbarBottleReporter(object):
             try:
                 return callback(*args, **kwargs)
             except Exception, e:
-                rollbar.report_exc_info(sys.exc_info(), request=bottle.request)
+                if not isinstance(e, bottle.BaseResponse):
+                    rollbar.report_exc_info(sys.exc_info(), request=bottle.request)
                 raise
 
         return wrapper


### PR DESCRIPTION
`bottle.HttpResponse` is raised like an exception in the normal bottle request-response cycle. This trips up the plugin and reports normal responses as errors. That's kind of stupid, so fixing that.

I had fixed this in a separate plugin I maintain for another project, and forgot to port it over to PR #8.

Sorry about that.
