### PR TITLE
use exception_level_filters instead of instanceof

### DIFF
--- a/rollbar/contrib/bottle/__init__.py
+++ b/rollbar/contrib/bottle/__init__.py
@@ -9,6 +9,11 @@ class RollbarBottleReporter(object):
     api = 2
 
     def __init__(self, *args, **kwargs):
+        if 'exception_level_filters' in kwargs:
+            kwargs['exception_level_filters'].append((bottle.BaseResponse, 'ignored'))
+        else:
+            kwargs['exception_level_filters'] = [(bottle.baseResponse, 'ignored')]
+
         rollbar.init(*args, **kwargs)
 
     def __call__(self, callback):
@@ -16,8 +21,7 @@ class RollbarBottleReporter(object):
             try:
                 return callback(*args, **kwargs)
             except Exception, e:
-                if not isinstance(e, bottle.BaseResponse):
-                    rollbar.report_exc_info(sys.exc_info(), request=bottle.request)
+                rollbar.report_exc_info(sys.exc_info(), request=bottle.request)
                 raise
 
         return wrapper


### PR DESCRIPTION
addresses https://github.com/rollbar/pyrollbar/issues/10

I'm not sure if there's anything I'm missing when it comes to `exception_level_filters` other than it's a list of tuples with the exception class and level.
