### PR TITLE
Support request objects from Django REST framework

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -29,6 +29,11 @@ except ImportError:
     DjangoHttpRequest = None
 
 try:
+    from rest_framework.request import Request as RestFrameworkRequest
+except ImportError:
+    RestFrameworkRequest = None
+
+try:
     from werkzeug.wrappers import Request as WerkzeugRequest
 except ImportError:
     WerkzeugRequest = None
@@ -545,6 +550,10 @@ def _build_request_data(request):
 
     # django
     if DjangoHttpRequest and isinstance(request, DjangoHttpRequest):
+        return _build_django_request_data(request)
+
+    # django rest framework
+    if RestFrameworkRequest and isinstance(request, RestFrameworkRequest):
         return _build_django_request_data(request)
 
     # werkzeug (flask)


### PR DESCRIPTION
This patch allows one to notify Rollbar with request context from within [Django REST framework](http://www.django-rest-framework.org/) views.

Rollbar's Django middleware works fine because at that point the request object is a standard HttpRequest, but if one calls `rollbar.report_exc_info` inside a REST framework view, the request context in silently ignored.

[Django REST framework extends Django's `HttpRequest` by composition](http://www.django-rest-framework.org/api-guide/requests#standard-httprequest-attributes), so that checking with `isinstance` doesn't identify it as compatible with Django's `HttpRequest`.
