### PR TITLE
Use LogRecords better - will lead to better grouping in Rollbar

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -3,7 +3,7 @@ Hooks for integrating with the python logging framework.
 
 Usage:
     import logging
-    from rollbar.logging import RollbarHandler
+    from rollbar.logger import RollbarHandler
 
     rollbar.init('ACCESS_TOKEN', 'ENVIRONMENT')
 
@@ -74,10 +74,29 @@ class RollbarHandler(logging.Handler):
             return
 
         exc_info = record.exc_info
-        message = record.getMessage() or self.format(record)
 
+        # use the original message, not the formatted one
+        message = record.msg
         request = rollbar.get_request()
-        extra_data = getattr(record, 'extra_data', {})
+        extra_data = {
+            'args': record.args, 
+            'record': {
+                'created': record.created,
+                'funcName': record.funcName,
+                'lineno': record.lineno,
+                'module': record.module,
+                'name': record.name,
+                'pathname': record.pathname,
+                'process': record.process,
+                'processName': record.processName,
+                'relativeCreated': record.relativeCreated,
+                'thread': record.thread,
+                'threadName': record.threadName
+            }
+        }
+
+        extra_data.update(getattr(record, 'extra_data', {}))
+
         payload_data = getattr(record, 'payload_data', {})
 
         self._add_history(record, payload_data)

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -1,0 +1,47 @@
+"""
+Tests for the RollbarHandler logging handler
+"""
+import copy
+import logging
+import mock
+import urllib
+
+import rollbar
+from rollbar.logger import RollbarHandler
+
+from . import BaseTest
+
+
+_test_access_token = 'aaaabbbbccccddddeeeeffff00001111'
+_test_environment = 'test'
+_default_settings = copy.deepcopy(rollbar.SETTINGS)
+
+
+class LogHandlerTest(BaseTest):
+    def setUp(self):
+        rollbar._initialized = False
+        rollbar.SETTINGS = copy.deepcopy(_default_settings)
+
+    def _create_logger(self):
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+
+        rollbar_handler = RollbarHandler(_test_access_token, _test_environment)
+        rollbar_handler.setLevel(logging.WARNING)
+
+        logger.addHandler(rollbar_handler)
+
+        return logger
+
+    @mock.patch('rollbar.send_payload')
+    def test_message_stays_unformatted(self, send_payload):
+        logger = self._create_logger()
+        logger.warning("Hello %d %s", 1, 'world')
+
+        payload = send_payload.call_args[0][0]
+        
+        self.assertEqual(payload['data']['body']['message']['body'], "Hello %d %s")
+        self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
+        
+        self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
+


### PR DESCRIPTION
- use the unformatted message string, instead of the formatted one
- include the message args in body.message.body.args
- include other properties of the [LogRecord](https://docs.python.org/2/library/logging.html#logrecord-objects) in body.message.body.record
