### PR TITLE
Reduce module load attempts

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -113,21 +113,29 @@ def get_request():
 
 
 def _get_bottle_request():
+    if BottleRequest is None:
+        return None
     from bottle import request
     return request
 
 
 def _get_flask_request():
+    if WerkzeugRequest is None:
+        return None
     from flask import request
     return request
 
 
 def _get_pyramid_request():
+    if WebobBaseRequest is None:
+        return None
     from pyramid.threadlocal import get_current_request
     return get_current_request()
 
 
 def _get_pylons_request():
+    if WebobBaseRequest is None:
+        return None
     from pylons import request
     return request
 

--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -77,9 +77,8 @@ class RollbarHandler(logging.Handler):
 
         # use the original message, not the formatted one
         message = record.msg
-        request = rollbar.get_request()
         extra_data = {
-            'args': record.args, 
+            'args': record.args,
             'record': {
                 'created': record.created,
                 'funcName': record.funcName,
@@ -104,8 +103,11 @@ class RollbarHandler(logging.Handler):
         # after we've added the history data, check to see if the
         # notify level is satisfied
         if record.levelno < self.notify_level:
-            return 
+            return
 
+        # Wait until we know we're going to send a report before trying to
+        # load the request
+        request = rollbar.get_request()
         uuid = None
         try:
             if exc_info:
@@ -159,5 +161,5 @@ class RollbarHandler(logging.Handler):
 
         if hasattr(record, 'rollbar_uuid'):
             data['uuid'] = record.rollbar_uuid
-        
+
         return data


### PR DESCRIPTION
When using the Rollbar logger, we've noticed a lot of noise in strace
attempting to the load the request objects from various web frameworks.

Since the request object is only used in the final report sent to
Rollbar, only attempt to get it when the code is sure it wants to send a
report.

Use the import checks already done for request objects to skip import
attempts for frameworks that can't possibly be available, as their base
request objects are not available.
