### PR TITLE
Fix memory leak in in history collection

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -144,10 +144,10 @@ class RollbarHandler(logging.Handler):
     def _add_history(self, record, payload_data):
         if hasattr(self._history, 'records'):
             records = self._history.records
-            record.history = list(records[-self.history_size:])
+            history = list(records[-self.history_size:])
 
-            if record.history:
-                history_data = [self._build_history_data(r) for r in record.history]
+            if history:
+                history_data = [self._build_history_data(r) for r in history]
                 payload_data.setdefault('server', {})['history'] = history_data
 
             records.append(record)


### PR DESCRIPTION
History is stored as a list of logger records. After determining the
history for a given record, that history was then added to the record.
This led to a tree of records. Even though the history in the logger was
truncated, active records in the history would continue to point to
inactive ones, and so on, causing a memory leak.

Since the history field on record objects was only used within the
_add_history method, convert it to a local variable, and kill the leak.