### PR TITLE
Catch BadRequest exception on invalid json

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -986,8 +986,11 @@ def _build_werkzeug_request_data(request):
         'files_keys': request.files.keys(),
     }
 
-    if request.json:
-        request_data['body'] = json.dumps(_scrub_obj(request.json))
+    try:
+        if request.json:
+            request_data['body'] = json.dumps(_scrub_obj(request.json))
+    except Exception:
+        pass
 
     return request_data
 


### PR DESCRIPTION
Flask raise an exception when trying to use the json accessor on a request where the content-type is set to JSON but the body is empty. Unfortunately Rollbar catch it only to crash again without sending a report to the server.
Here's a Rollbar stacktrace:
```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.4/site-packages/rollbar/__init__.py", line 761, in _add_request_data
    request_data = _build_request_data(request)
  File "/app/.heroku/python/lib/python3.4/site-packages/rollbar/__init__.py", line 804, in _build_request_data
    return _build_werkzeug_request_data(actual_request)
  File "/app/.heroku/python/lib/python3.4/site-packages/rollbar/__init__.py", line 989, in _build_werkzeug_request_data
    if request.json:
  File "/app/.heroku/python/lib/python3.4/site-packages/flask/wrappers.py", line 108, in json
    return self.get_json()
  File "/app/.heroku/python/lib/python3.4/site-packages/flask/wrappers.py", line 145, in get_json
    rv = self.on_json_loading_failed(e)
  File "/app/.heroku/python/lib/python3.4/site-packages/flask/wrappers.py", line 162, in on_json_loading_failed
    raise BadRequest()
werkzeug.exceptions.BadRequest: 400: Bad Request
```