### PR TITLE
Use request from log record if present.

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -107,7 +107,8 @@ class RollbarHandler(logging.Handler):
 
         # Wait until we know we're going to send a report before trying to
         # load the request
-        request = rollbar.get_request()
+        request = getattr(record, "request", None) or rollbar.get_request()
+
         uuid = None
         try:
             if exc_info:

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -5,6 +5,7 @@ import copy
 import logging
 import mock
 import urllib
+import sys
 
 import rollbar
 from rollbar.logger import RollbarHandler
@@ -39,9 +40,28 @@ class LogHandlerTest(BaseTest):
         logger.warning("Hello %d %s", 1, 'world')
 
         payload = send_payload.call_args[0][0]
-        
+
         self.assertEqual(payload['data']['body']['message']['body'], "Hello %d %s")
         self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
-        
+
         self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
 
+
+    def test_request_is_get_from_log_record_if_present(self):
+        logger = self._create_logger()
+        # Request objects vary depending on python frameworks or packages.
+        # Using a dictionary for this test is enough.
+        request = {"fake": "request", "for":  "testing purporse"}
+
+        # No need to test request parsing and payload sent,
+        # just need to be sure that proper rollbar function is called
+        # with passed request as argument.
+        with mock.patch("rollbar.report_message") as report_message_mock:
+            logger.warning("Warning message", extra={"request": request})
+            self.assertEquals(report_message_mock.call_args[1]["request"], request)
+
+        # Python 2.6 doesnt support extra param in logger.exception.
+        if not sys.version_info[:2] == (2, 6):
+            with mock.patch("rollbar.report_exc_info") as report_exc_info:
+                logger.exception("Exception message", extra={"request": request})
+                self.assertEquals(report_exc_info.call_args[1]["request"], request)


### PR DESCRIPTION
Hello.

We're using rollbar at Agroptima in a django project.  Uncatched exceptions are correctly processed by middleware, and exception is send to rollbar API among with request. So request and user data are parsed and show in rollbar web UI.  This is very convenient. 

But when we send a log event using python's logging standard:

```python
import logging
logger = logging.getLogger()
logger.warning("Warning message")
```
Rollbar's log handler is not able to guess the current request when used from Django, Actually, the "build_request" method is not able to do it, and since there's no good way of guessing the current request in Django, that's probably OK.

If we try:
```python
logger.warning("Warning message", extra={"request": request}})
```
Log handler's code ignores everything passed within extra parameter. I guess this is done this way to tell apart log record attributes and custom extra data, which is expected in "extra_data" log record attribute. Ok, that's a different issue. We just want to inject the request by now, so we try: 

```python
logger.warning("Warning message", extra={"extra_data": {"request": request}})
```
But request is still not parsed nor sent to rollbar API as request data, since log handler is trying to guess the request using "build_request" method, which is worthless for Django. The passed request appears only as a truncated param, not as proper request data.

In this PR I suggest a solution that allows to pass current request to log handler in a standard way, using the "extra" parameter in a logger call. 