### PR TITLE
Don't try to build request data if outside request context

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -800,7 +800,10 @@ def _build_request_data(request):
         return _build_werkzeug_request_data(request)
 
     if WerkzeugLocalProxy and isinstance(request, WerkzeugLocalProxy):
-        actual_request = request._get_current_object()
+        try:
+            actual_request = request._get_current_object()
+        except RuntimeError:
+            return None
         return _build_werkzeug_request_data(actual_request)
 
     # tornado


### PR DESCRIPTION
When using the rollbar log handler in Flask apps, if you try to report errors outside the request context (e.g. in background workers), you'll see RuntimeErrors in your local logs as rollbar tries to populate the request data for the error report.

This commit cleans up the logs by suppressing that exception.