### PR TITLE
Fixes bug that caused some payload fields to become invalid

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -669,7 +669,6 @@ def _report_message(message, level, request, extra_data, payload_data):
     }
 
     if extra_data:
-        #extra_data = _scrub_obj(extra_data)
         extra_data = extra_data
         data['body']['message'].update(extra_data)
 
@@ -1037,7 +1036,6 @@ def _build_werkzeug_request_data(request):
 
     try:
         if request.json:
-            #request_data['body'] = json.dumps(_scrub_obj(request.json))
             request_data['body'] = request.json
     except Exception:
         pass
@@ -1124,8 +1122,8 @@ def _build_server_data():
     return server_data
 
 
-def _transform(obj):
-    return transforms.transform(obj, *_transforms)
+def _transform(obj, key=None):
+    return transforms.transform(obj, _transforms, key=key)
 
 
 def _build_payload(data):
@@ -1133,9 +1131,15 @@ def _build_payload(data):
     Returns the full payload as a string.
     """
 
+    data['body'] = _transform(data['body'], key=('body',))
+    data['server'] = _transform(data['server'], key=('server',))
+
+    if 'request' in data:
+        data['request'] = _transform(data['request'], key=('request',))
+
     payload = {
         'access_token': SETTINGS['access_token'],
-        'data': _transform(data)
+        'data': data
     }
 
     return json.dumps(payload)

--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -59,7 +59,8 @@ class Transform(object):
 
 
 
-def transform(obj, *transforms):
+def transform(obj, transforms, key=None):
+    key = key or ()
 
     def do_transforms(type_name, val, key=None, **kw):
         for transform in transforms:
@@ -103,7 +104,7 @@ def transform(obj, *transforms):
         'allowed_circular_reference_types': _ALLOWED_CIRCULAR_REFERENCE_TYPES
     }
 
-    return traverse.traverse(obj, **handlers)
+    return traverse.traverse(obj, key=key, **handlers)
 
 
 __all__ = ['transform', 'Transform']

--- a/rollbar/test/test_scrub_transform.py
+++ b/rollbar/test/test_scrub_transform.py
@@ -10,7 +10,7 @@ from rollbar.test import BaseTest, SNOWMAN
 class ScrubTransformTest(BaseTest):
     def _assertScrubbed(self, suffixes, start, expected, redact_char='*', skip_id_check=False):
         scrubber = ScrubTransform(suffixes=suffixes, redact_char=redact_char, randomize_len=False)
-        result = transforms.transform(start, scrubber)
+        result = transforms.transform(start, [scrubber])
 
         """
         print start
@@ -145,7 +145,7 @@ class ScrubTransformTest(BaseTest):
         ref['circular'] = obj
 
         scrubber = ScrubTransform([])
-        result = transforms.transform(obj, scrubber)
+        result = transforms.transform(obj, [scrubber])
 
         self.assertIsNot(result, obj)
         self.assertIsNot(result['password'], ref)

--- a/rollbar/test/test_scruburl_transform.py
+++ b/rollbar/test/test_scruburl_transform.py
@@ -26,7 +26,7 @@ class ScrubUrlTransformTest(BaseTest):
                                      scrub_password=scrub_password,
                                      redact_char=redact_char,
                                      randomize_len=False)
-        result = transforms.transform(start, scrubber)
+        result = transforms.transform(start, [scrubber])
 
         """
         print(start)
@@ -124,7 +124,7 @@ class ScrubUrlTransformTest(BaseTest):
         }
 
         scrubber = ScrubUrlTransform(suffixes=[('url',)], params_to_scrub=['password'], randomize_len=False)
-        result = transforms.transform(obj, scrubber)
+        result = transforms.transform(obj, [scrubber])
 
         expected = copy.deepcopy(obj)
         self.assertDictEqual(expected, result)
@@ -139,7 +139,7 @@ class ScrubUrlTransformTest(BaseTest):
         }
 
         scrubber = ScrubUrlTransform(suffixes=[('url',), ('link',)], params_to_scrub=['password'], randomize_len=False)
-        result = transforms.transform(obj, scrubber)
+        result = transforms.transform(obj, [scrubber])
 
         self.assertNotIn('secr3t', result['url'][0]['link'])
         self.assertNotIn('secret', result['url'][0]['link'])

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -26,7 +26,7 @@ undecodable_repr = '<Undecodable type:(%s) base64:(%s)>' % (binary_type_name, in
 class SerializableTransformTest(BaseTest):
     def _assertSerialized(self, start, expected, whitelist=None, skip_id_check=False):
         serializable = SerializableTransform(whitelist_types=whitelist)
-        result = transforms.transform(start, serializable)
+        result = transforms.transform(start, [serializable])
 
         """
         #print start
@@ -88,7 +88,7 @@ class SerializableTransformTest(BaseTest):
         start = float('nan')
 
         serializable = SerializableTransform()
-        result = transforms.transform(start, serializable)
+        result = transforms.transform(start, [serializable])
 
         self.assertTrue(math.isnan(result))
 
@@ -96,7 +96,7 @@ class SerializableTransformTest(BaseTest):
         start = float('inf')
 
         serializable = SerializableTransform()
-        result = transforms.transform(start, serializable)
+        result = transforms.transform(start, [serializable])
 
         self.assertTrue(math.isinf(result))
 
@@ -184,7 +184,7 @@ class SerializableTransformTest(BaseTest):
         start = {'hello': 'world', 'custom': CustomRepr()}
 
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, serializable)
+        result = transforms.transform(start, [serializable])
 
         if python_major_version() < 3:
             self.assertEqual(result['custom'], b'hello')
@@ -199,7 +199,7 @@ class SerializableTransformTest(BaseTest):
         start = {'hello': 'world', 'custom': CustomRepr()}
 
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, serializable)
+        result = transforms.transform(start, [serializable])
         self.assertRegex(result['custom'], "<class '.*CustomRepr'>")
 
     def test_encode_with_custom_repr_returns_unicode(self):


### PR DESCRIPTION
The problem was that the serializer was being run on the final payload
object which had references in the request dict to local variables in
the trace frames. This caused request.params = <CircularReference ...>
which is invalid according to the Rollbar API schema.

This change serializes the payload in sections so that each section
cannot reference the other while checking for circular references.

@brianr