### PR TITLE
Implemented a more robust filtering mechanism

### DIFF
--- a/rollbar/lib/events.py
+++ b/rollbar/lib/events.py
@@ -1,0 +1,99 @@
+EXCEPTION_INFO = 'exception_info'
+MESSAGE = 'message'
+PAYLOAD = 'payload'
+
+_event_handlers = {
+    EXCEPTION_INFO: [],
+    MESSAGE: [],
+    PAYLOAD: []
+}
+
+
+def _check_type(type):
+    if type not in _event_handlers:
+        raise ValueError('Unknown type: %s. Must be one of %s' % (type, _event_handlers.keys()))
+
+
+def _add_handler(type, handler_fn, pos):
+    _check_type(type)
+
+    pos = pos if pos is not None else -1
+    handlers = _event_handlers[type]
+
+    try:
+        handlers.index(handler_fn)
+    except ValueError:
+        handlers.insert(pos, handler_fn)
+
+
+def _remove_handler(type, handler_fn):
+    _check_type(type)
+
+    handlers = _event_handlers[type]
+
+    try:
+        index = handlers.index(handler_fn)
+        handlers.pop(index)
+    except ValueError:
+        pass
+
+
+def _on_event(type, target, **kw):
+    _check_type(type)
+
+    ref = target
+    for handler in _event_handlers[type]:
+        result = handler(ref, **kw)
+        if result is False:
+            return False
+
+        ref = result
+
+    return ref
+
+
+# Add/remove event handlers
+
+def add_exception_info_handler(handler_fn, pos=None):
+    _add_handler(EXCEPTION_INFO, handler_fn, pos)
+
+
+def remove_exception_info_handler(handler_fn):
+    _remove_handler(EXCEPTION_INFO, handler_fn)
+
+
+def add_message_handler(handler_fn, pos=None):
+    _add_handler(MESSAGE, handler_fn, pos)
+
+
+def remove_message_handler(handler_fn):
+    _remove_handler(MESSAGE, handler_fn)
+
+
+def add_payload_handler(handler_fn, pos=None):
+    _add_handler(PAYLOAD, handler_fn, pos)
+
+
+def remove_payload_handler(handler_fn):
+    _remove_handler(PAYLOAD, handler_fn)
+
+
+# Event handler processing
+
+def on_exception_info(exc_info, **kw):
+    return _on_event(EXCEPTION_INFO, exc_info, **kw)
+
+
+def on_message(message, **kw):
+    return _on_event(MESSAGE, message, **kw)
+
+
+def on_payload(payload, **kw):
+    return _on_event(PAYLOAD, payload, **kw)
+
+
+# Misc
+
+def reset():
+    for handlers in _event_handlers.values():
+        del handlers[:]

--- a/rollbar/lib/events.py
+++ b/rollbar/lib/events.py
@@ -9,16 +9,16 @@ _event_handlers = {
 }
 
 
-def _check_type(type):
-    if type not in _event_handlers:
-        raise ValueError('Unknown type: %s. Must be one of %s' % (type, _event_handlers.keys()))
+def _check_type(typ):
+    if typ not in _event_handlers:
+        raise ValueError('Unknown type: %s. Must be one of %s' % (typ, _event_handlers.keys()))
 
 
-def _add_handler(type, handler_fn, pos):
-    _check_type(type)
+def _add_handler(typ, handler_fn, pos):
+    _check_type(typ)
 
     pos = pos if pos is not None else -1
-    handlers = _event_handlers[type]
+    handlers = _event_handlers[typ]
 
     try:
         handlers.index(handler_fn)
@@ -26,10 +26,10 @@ def _add_handler(type, handler_fn, pos):
         handlers.insert(pos, handler_fn)
 
 
-def _remove_handler(type, handler_fn):
-    _check_type(type)
+def _remove_handler(typ, handler_fn):
+    _check_type(typ)
 
-    handlers = _event_handlers[type]
+    handlers = _event_handlers[typ]
 
     try:
         index = handlers.index(handler_fn)
@@ -38,11 +38,11 @@ def _remove_handler(type, handler_fn):
         pass
 
 
-def _on_event(type, target, **kw):
-    _check_type(type)
+def _on_event(typ, target, **kw):
+    _check_type(typ)
 
     ref = target
-    for handler in _event_handlers[type]:
+    for handler in _event_handlers[typ]:
         result = handler(ref, **kw)
         if result is False:
             return False

--- a/rollbar/lib/filters/__init__.py
+++ b/rollbar/lib/filters/__init__.py
@@ -1,0 +1,11 @@
+from rollbar.lib import events
+from rollbar.lib.filters.basic import filter_rollbar_ignored_exceptions, filter_by_level
+
+
+def add_builtin_filters(settings):
+    # exc_info filters
+    events.add_exception_info_handler(filter_rollbar_ignored_exceptions)
+    events.add_exception_info_handler(filter_by_level)
+
+    # message filters
+    events.add_message_handler(filter_by_level)

--- a/rollbar/lib/filters/basic.py
+++ b/rollbar/lib/filters/basic.py
@@ -1,0 +1,13 @@
+def filter_rollbar_ignored_exceptions(exc_info, **kw):
+    cls, exc, trace = exc_info
+    if getattr(exc, '_rollbar_ignore', False):
+        return False
+
+    return exc_info
+
+
+def filter_by_level(target, **kw):
+    if 'level' in kw and kw['level'] == 'ignored':
+        return False
+
+    return target

--- a/rollbar/lib/filters/basic.py
+++ b/rollbar/lib/filters/basic.py
@@ -1,5 +1,5 @@
 def filter_rollbar_ignored_exceptions(exc_info, **kw):
-    cls, exc, trace = exc_info
+    _, exc, _ = exc_info
     if getattr(exc, '_rollbar_ignore', False):
         return False
 

--- a/rollbar/test/flask_tests/test_flask.py
+++ b/rollbar/test/flask_tests/test_flask.py
@@ -82,7 +82,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
             self.assertEqual(resp.status_code, 500)
 
             self.assertEqual(send_payload.called, True)
-            payload = json.loads(send_payload.call_args[0][0])
+            payload = send_payload.call_args[0][0]
             data = payload['data']
 
             self.assertIn('body', data)
@@ -110,7 +110,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
             self.assertEqual(resp.status_code, 500)
 
             self.assertEqual(send_payload.called, True)
-            payload = json.loads(send_payload.call_args[0][0])
+            payload = send_payload.call_args[0][0]
             data = payload['data']
 
             self.assertIn('body', data)

--- a/rollbar/test/test_basic_filters.py
+++ b/rollbar/test/test_basic_filters.py
@@ -1,0 +1,29 @@
+from rollbar.lib import events, filters
+
+from rollbar.test import BaseTest
+
+
+class BasicFiltersTest(BaseTest):
+    def setUp(self):
+        events.reset()
+        filters.add_builtin_filters({})
+
+    def test_rollbar_ignored_exception(self):
+        class IgnoredException(Exception):
+            _rollbar_ignore = True
+
+        class NotIgnoredException(Exception):
+            _rollbar_ignore = False
+
+        self.assertFalse(events.on_exception_info((None, IgnoredException(), None)))
+        self.assertIsNot(events.on_exception_info((None, NotIgnoredException(), None)), False)
+
+    def test_filter_by_level(self):
+        self.assertFalse(events.on_exception_info((None, 123, None), level='ignored'))
+        self.assertIsNot(events.on_exception_info((None, 123, None), level='error'), False)
+
+        self.assertFalse(events.on_message('hello world', level='ignored'))
+        self.assertIsNot(events.on_message('hello world', level='error'), False)
+
+        self.assertFalse(events.on_payload({}, level='ignored'))
+        self.assertIsNot(events.on_message({}, level='error'), False)

--- a/rollbar/test/test_custom_filters.py
+++ b/rollbar/test/test_custom_filters.py
@@ -1,0 +1,50 @@
+import re
+
+from rollbar.lib import events, filters
+
+from rollbar.test import BaseTest
+
+
+class CustomFiltersTest(BaseTest):
+    def setUp(self):
+        events.reset()
+        filters.add_builtin_filters({})
+
+    def test_ignore_by_setting_rollbar_ignore(self):
+        class NotIgnoredByDefault(Exception):
+            pass
+
+        def _ignore_if_cruel_world_filter(exc_info, **kw):
+            cls, exc, trace = exc_info
+            if 'cruel world' in str(exc):
+                exc._rollbar_ignore = True
+
+            return exc_info
+
+        events.add_exception_info_handler(_ignore_if_cruel_world_filter, pos=0)
+
+        self.assertIsNot(events.on_exception_info((None, NotIgnoredByDefault('hello world'), None)), False)
+        self.assertFalse(events.on_exception_info((None, NotIgnoredByDefault('hello cruel world'), None)))
+
+    def test_ignore_messages_by_regex(self):
+        regex = re.compile(r'cruel')
+
+        def _ignore_cruel_world_substring(message, **kw):
+            if regex.search(message):
+                return False
+
+            return message
+
+        events.add_message_handler(_ignore_cruel_world_substring)
+
+        self.assertFalse(events.on_message('hello cruel world'))
+        self.assertIsNot(events.on_message('hello world'), False)
+
+    def test_modify_payload(self):
+        def _add_test_key(payload, **kw):
+            payload['test'] = 333
+            return payload
+
+        events.add_payload_handler(_add_test_key)
+
+        self.assertEqual(events.on_payload({'hello': 'world'}), {'hello': 'world', 'test': 333})

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -42,10 +42,10 @@ class LogHandlerTest(BaseTest):
         logger = self._create_logger()
         logger.warning("Hello %d %s", 1, 'world')
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['data']['body']['message']['body'], "Hello %d %s")
-        self.assertEqual(payload['data']['body']['message']['args'], [1, 'world'])
+        self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
         self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
 
     def test_request_is_get_from_log_record_if_present(self):

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -108,7 +108,7 @@ class LogHandlerTest(BaseTest):
         _raise_ex()
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         body = payload['data']['body']
         trace = body['trace'] if 'trace' in body else None
         trace_chain = body['trace_chain'] if 'trace_chain' in body else None
@@ -137,7 +137,7 @@ class LogHandlerTest(BaseTest):
         _raise_ex()
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         body = payload['data']['body']
         trace = body['trace'] if 'trace' in body else None
         trace_chain = body['trace_chain'] if 'trace_chain' in body else None

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -125,7 +125,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['access_token'], _test_access_token)
         self.assertIn('body', payload['data'])
@@ -367,7 +367,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['access_token'], _test_access_token)
         self.assertIn('body', payload['data'])
@@ -379,7 +379,7 @@ class RollbarTest(BaseTest):
     def test_uuid(self, send_payload):
         uuid = rollbar.report_message('foo')
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['data']['uuid'], uuid)
 
@@ -392,7 +392,7 @@ class RollbarTest(BaseTest):
             rollbar.report_exc_info()
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         self.assertEqual(payload['data']['level'], 'error')
 
         try:
@@ -401,7 +401,7 @@ class RollbarTest(BaseTest):
             rollbar.report_exc_info(level='info')
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         self.assertEqual(payload['data']['level'], 'info')
 
         # payload takes precendence over 'level'
@@ -411,7 +411,7 @@ class RollbarTest(BaseTest):
             rollbar.report_exc_info(level='info', payload_data={'level': 'warn'})
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         self.assertEqual(payload['data']['level'], 'warn')
 
     @mock.patch('rollbar.send_payload')
@@ -489,7 +489,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -510,7 +510,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -529,7 +529,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -553,7 +553,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -577,7 +577,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -600,7 +600,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -628,7 +628,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -652,7 +652,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -682,7 +682,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -720,7 +720,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -744,7 +744,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -770,7 +770,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('kwargs', payload['data']['body']['trace']['frames'][-1]['locals'])
@@ -860,7 +860,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['password'], '\*+')
         self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['Password'], '\*+')
@@ -885,7 +885,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual('<Infinity>', payload['data']['body']['trace']['frames'][-1]['locals']['infinity'])
         self.assertEqual('<NegativeInfinity>', payload['data']['body']['trace']['frames'][-1]['locals']['negative_infinity'])
@@ -910,7 +910,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertTrue(
             (isinstance(payload['data']['body']['trace']['frames'][-1]['locals']['obj'], dict) and
@@ -941,7 +941,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual('sensitive', payload['data']['body']['trace']['frames'][-1]['locals']['copy'])
 
@@ -959,7 +959,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -988,7 +988,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -1021,7 +1021,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -1047,7 +1047,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         for frame in payload['data']['body']['trace']['frames']:
             self.assertIn('locals', frame)
 
@@ -1066,7 +1066,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         num_frames = len(payload['data']['body']['trace']['frames'])
         for i, frame in enumerate(payload['data']['body']['trace']['frames']):
@@ -1090,7 +1090,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         frames = payload['data']['body']['trace']['frames']
         called_with_frame = frames[1]
@@ -1108,7 +1108,7 @@ class RollbarTest(BaseTest):
             rollbar.report_exc_info()
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         self.assertEqual(payload['data']['body']['trace']['exception']['message'], message)
 
     @mock.patch('rollbar.lib.transport.post', side_effect=lambda *args, **kw: MockResponse({'status': 'OK'}, 200))

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -262,7 +262,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['access_token'], _test_access_token)
         self.assertIn('body', payload['data'])
@@ -307,7 +307,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['access_token'], _test_access_token)
         self.assertIn('body', payload['data'])
@@ -420,7 +420,7 @@ class RollbarTest(BaseTest):
         rollbar.report_exc_info(exc_info=(None, None, None))
 
         self.assertEqual(send_payload.called, True)
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
         self.assertEqual(payload['data']['level'], 'error')
 
     @mock.patch('rollbar._send_failsafe')
@@ -464,7 +464,7 @@ class RollbarTest(BaseTest):
 
         rollbar._send_failsafe('test message', test_uuid, test_host)
         self.assertEqual(send_payload.call_count, 1)
-        self.assertEqual(json.loads(send_payload.call_args[0][0]), test_data)
+        self.assertEqual(send_payload.call_args[0][0], test_data)
 
     @mock.patch('rollbar.log.exception')
     @mock.patch('rollbar.send_payload', side_effect=Exception('Monkey Business!'))
@@ -795,7 +795,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -821,7 +821,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(send_payload.called, True)
 
-        payload = json.loads(send_payload.call_args[0][0])
+        payload = send_payload.call_args[0][0]
 
         self.assertNotIn('argspec', payload['data']['body']['trace']['frames'][-1])
         self.assertNotIn('varargspec', payload['data']['body']['trace']['frames'][-1])
@@ -1140,7 +1140,7 @@ class RollbarTest(BaseTest):
         self.assertIn('bug bug', payload_data)
 
         try:
-            json.loads(post.call_args[1]['data'])
+            post.call_args[1]['data']
         except:
             self.assertTrue(False)
 

--- a/rollbar/test/twisted_tests/test_twisted.py
+++ b/rollbar/test/twisted_tests/test_twisted.py
@@ -60,7 +60,7 @@ if ALLOWED_PYTHON_VERSION and TWISTED_INSTALLED:
             self.assertEqual(len(errors), 1)
 
             self.assertEqual(send_payload.called, True)
-            payload = json.loads(send_payload.call_args[0][0])
+            payload = send_payload.call_args[0][0]
             data = payload['data']
 
             self.assertIn('body', data)
@@ -78,7 +78,7 @@ if ALLOWED_PYTHON_VERSION and TWISTED_INSTALLED:
         #     self.assertEqual(len(errors), 1)
         #
         #     self.assertEqual(send_payload.called, True)
-        #     payload = json.loads(send_payload.call_args[0][0])
+        #     payload = send_payload.call_args[0][0]
         #     data = payload['data']
         #
         #     self.assertIn('body', data)


### PR DESCRIPTION
You can now add custom filtering logic to determine if the error/message/payload
should be sent to Rollbar.

e.g. Only send messages that match a regular expression:

``` py
import re

import rollbar
from rollbar import events

def ignore_unimportant_messages(message, **kw):
    if re.search(r'everthing is broken', message):
        return message
    return False

events.add_message_handler(ignore_unimportant_messages)

# This will not report to Rollbar
rollbar.report_message('everything is fine...')
# This will report to Rollbar
rollbar.report_message('everything is broken')
```

@brianr cc @Crisfole 
