### PR TITLE
Add safe_repr option to serializer and expose serializer's whitelist_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ Default: ```thread```
           <dd>Default 100</dd>
         </dl>
       </dd>
+      <dt>whitelisted_types</dt>
+      <dd>A list of `type` objects, (e.g. `type(my_class_instance)` or `MyClass`) that will be serialized using
+      `repr()`. Default `[]`</dd>
     </dl>
   </dd>
   <dt>root</dt>

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -287,7 +287,8 @@ SETTINGS = {
     'locals': {
         'enabled': True,
         'safe_repr': True,
-        'sizes': DEFAULT_LOCALS_SIZES
+        'sizes': DEFAULT_LOCALS_SIZES,
+        'whitelisted_types': []
     },
     'verify_https': True
 }
@@ -331,7 +332,8 @@ def init(access_token, environment='production', **kw):
     # 3. Scrub URLs in the payload for keys that end with 'url'
     # 4. Optional - If local variable gathering is enabled, transform the
     #       trace frame values using the ShortReprTransform.
-    _serialize_transform = SerializableTransform()
+    _serialize_transform = SerializableTransform(safe_repr=SETTINGS['locals']['safe_repr'],
+                                                 whitelist_types=SETTINGS['locals']['whitelisted_types'])
     _transforms = [
         _serialize_transform,
         ScrubTransform(suffixes=[(field,) for field in SETTINGS['scrub_fields']], redact_char='*'),

--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -8,8 +8,9 @@ from rollbar.lib.transforms import Transform
 
 
 class SerializableTransform(Transform):
-    def __init__(self, whitelist_types=None):
+    def __init__(self, safe_repr=True, whitelist_types=None):
         super(SerializableTransform, self).__init__()
+        self.safe_repr = safe_repr
         self.whitelist = set(whitelist_types or [])
 
     def transform_circular_reference(self, o, key=None, ref_key=None):
@@ -80,6 +81,14 @@ class SerializableTransform(Transform):
             except TypeError:
                 pass
 
+        # If self.safe_repr is False, use repr() to serialize the object
+        if not self.safe_repr:
+            try:
+                return repr(o)
+            except TypeError:
+                pass
+
+        # Otherwise, just use the type name
         return str(type(o))
 
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -36,7 +36,7 @@ class RollbarTest(BaseTest):
         rollbar.init(_test_access_token, locals={'enabled': True}, dummy_key='asdf', handler='blocking', timeout=12345)
 
     def test_merged_settings(self):
-        expected = {'enabled': True, 'sizes': rollbar.DEFAULT_LOCALS_SIZES, 'safe_repr': True}
+        expected = {'enabled': True, 'sizes': rollbar.DEFAULT_LOCALS_SIZES, 'safe_repr': True, 'whitelisted_types': []}
         self.assertDictEqual(rollbar.SETTINGS['locals'], expected)
         self.assertEqual(rollbar.SETTINGS['timeout'], 12345)
         self.assertEqual(rollbar.SETTINGS['dummy_key'], 'asdf')

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -24,8 +24,8 @@ undecodable_repr = '<Undecodable type:(%s) base64:(%s)>' % (binary_type_name, in
 
 
 class SerializableTransformTest(BaseTest):
-    def _assertSerialized(self, start, expected, whitelist=None, skip_id_check=False):
-        serializable = SerializableTransform(whitelist_types=whitelist)
+    def _assertSerialized(self, start, expected, safe_repr=True, whitelist=None, skip_id_check=False):
+        serializable = SerializableTransform(safe_repr=safe_repr, whitelist_types=whitelist)
         result = transforms.transform(start, [serializable])
 
         """
@@ -152,7 +152,27 @@ class SerializableTransformTest(BaseTest):
         del expected[invalid]
         self._assertSerialized(start, expected)
 
-    def test_encode_with_custom_repr(self):
+    def test_encode_with_custom_repr_no_whitelist(self):
+        class CustomRepr(object):
+            def __repr__(self):
+                return 'hello'
+
+        start = {'hello': 'world', 'custom': CustomRepr()}
+        expected = copy.deepcopy(start)
+        expected['custom'] = str(CustomRepr)
+        self._assertSerialized(start, expected)
+
+    def test_encode_with_custom_repr_no_whitelist_no_safe_repr(self):
+        class CustomRepr(object):
+            def __repr__(self):
+                return 'hello'
+
+        start = {'hello': 'world', 'custom': CustomRepr()}
+        expected = copy.deepcopy(start)
+        expected['custom'] = 'hello'
+        self._assertSerialized(start, expected, safe_repr=False)
+
+    def test_encode_with_custom_repr_whitelist(self):
         class CustomRepr(object):
             def __repr__(self):
                 return 'hello'


### PR DESCRIPTION
…types param

This allows users to configure Rollbar to use `repr(obj)` during the
serialization stage.

@jfarrimo cc @brianr