### PR TITLE
no exc_info when not in exception handler

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -111,19 +111,19 @@ class RollbarHandler(logging.Handler):
 
         uuid = None
         try:
-            if exc_info:
+            # when not in an exception handler, exc_info == (None, None, None)
+            if exc_info and exc_info[0]:
                 if message:
                     message_template = {
                         'body': {
                             'trace': {
                                 'exception': {
                                     'description': message
-                                 }
+                                }
                             }
                         }
                     }
                     payload_data = rollbar.dict_merge(payload_data, message_template)
-
 
                 uuid = rollbar.report_exc_info(exc_info,
                                                level=level,

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -63,17 +63,17 @@ class LogHandlerTest(BaseTest):
             # if you call logger.exception outside of an exception
             # handler, it shouldn't try to report exc_info, since it
             # won't have any
-            with mock.patch("rollbar.report_exc_info") as report_exc_info,\
-                 mock.patch("rollbar.report_message") as report_message_mock:
-                logger.exception("Exception message", extra={"request": request})
-                report_exc_info.assert_not_called()
-                self.assertEqual(report_message_mock.call_args[1]["request"], request)
-
-            with mock.patch("rollbar.report_exc_info") as report_exc_info,\
-                 mock.patch("rollbar.report_message") as report_message_mock:
-                try:
-                    raise Exception()
-                except:
+            with mock.patch("rollbar.report_exc_info") as report_exc_info:
+                with mock.patch("rollbar.report_message") as report_message_mock:
                     logger.exception("Exception message", extra={"request": request})
-                    self.assertEqual(report_exc_info.call_args[1]["request"], request)
-                    report_message_mock.assert_not_called()
+                    report_exc_info.assert_not_called()
+                    self.assertEqual(report_message_mock.call_args[1]["request"], request)
+
+            with mock.patch("rollbar.report_exc_info") as report_exc_info:
+                with mock.patch("rollbar.report_message") as report_message_mock:
+                    try:
+                        raise Exception()
+                    except:
+                        logger.exception("Exception message", extra={"request": request})
+                        self.assertEqual(report_exc_info.call_args[1]["request"], request)
+                        report_message_mock.assert_not_called()

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -60,6 +60,20 @@ class LogHandlerTest(BaseTest):
 
         # Python 2.6 doesnt support extra param in logger.exception.
         if not sys.version_info[:2] == (2, 6):
-            with mock.patch("rollbar.report_exc_info") as report_exc_info:
+            # if you call logger.exception outside of an exception
+            # handler, it shouldn't try to report exc_info, since it
+            # won't have any
+            with mock.patch("rollbar.report_exc_info") as report_exc_info,\
+                 mock.patch("rollbar.report_message") as report_message_mock:
                 logger.exception("Exception message", extra={"request": request})
-                self.assertEqual(report_exc_info.call_args[1]["request"], request)
+                report_exc_info.assert_not_called()
+                self.assertEqual(report_message_mock.call_args[1]["request"], request)
+
+            with mock.patch("rollbar.report_exc_info") as report_exc_info,\
+                 mock.patch("rollbar.report_message") as report_message_mock:
+                try:
+                    raise Exception()
+                except:
+                    logger.exception("Exception message", extra={"request": request})
+                    self.assertEqual(report_exc_info.call_args[1]["request"], request)
+                    report_message_mock.assert_not_called()


### PR DESCRIPTION
We were incorrectly testing for the existence of exc_info in our custom
log handler.  Apparently, it's not None when there's no exception
information (when log.exception is not called from an exception
handler).  When you call log.exception from outside of an exception
handler, then exc_info == (None, None, None).

@brianr