### PR TITLE
Manipulate SETTINGS before actually initializing anything

### DIFF
--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -792,8 +792,9 @@ class RollbarTest(BaseTest):
             self.assertTrue(False)
 
     def test_scrub_webob_request_data(self):
-        rollbar.SETTINGS['scrub_fields'].extend(['token', 'secret', 'cookies', 'authorization'])
-        rollbar.init(_test_access_token, locals={'enabled': True}, dummy_key='asdf', handler='blocking', timeout=12345)
+        rollbar._initialized = False
+        rollbar.init(_test_access_token, locals={'enabled': True}, dummy_key='asdf', handler='blocking', timeout=12345,
+            scrub_fields=rollbar.SETTINGS['scrub_fields'] + ['token', 'secret', 'cookies', 'authorization'])
 
         import webob
         request = webob.Request.blank('/the/path?q=hello&password=hunter2',


### PR DESCRIPTION
Previously, SETTINGS would be manipulated *after* various pyrollbar internals were configured. This worked well enough for many features, because they actually referenced SETTINGS after the fact, so it didn't really matter when it was manipulated. But `scrub_fields`, was being used to configure the various transforms *before* any custom `scrub_fields` argument was added to SETTINGS.

This meant the only ways to have a custom `scrub_fields` take effect were to either modify SETTINGS manually prior to running `rollbar.init`, or simply call `rollbar.init` twice. The latter worked because of another bug in `rollbar.init`, where the "already initialized" check would only occur *after* actually initializing everything. Failing to do one of these things would result in any custom `scrub_fields` entries to simply be ignored, as pyrollbar would just use the default entries.

This PR moves the SETTINGS manipulation up higher in `rollbar.init`, so that it takes place prior to any actual initialization. It also moves up the check for whether `rollbar.init` has already been called, so that a second call will truly do nothing. The comment about the future `configure()` method remains intact.

I also found a test that actually did both of the above-listed workarounds, in order to get a custom set of `scrub_fields` to work properly, so this seems to have been a known bug at some point. I've fixed the test so that `scrub_fields` is passed in as an argument, as it would be for normal users. But to get around the new "already initialized" behavior, I had to manually set `rollbar._initialized` to False, because `rollbar.init` is already called once in the test setup. This seems to maintain the original spirit of the test, while working much more like a normal user would use it.