### PR TITLE
Remove access token parameter from agent logging call

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -437,7 +437,7 @@ def send_payload(payload, access_token):
     if handler == 'blocking':
         _send_payload(payload, access_token)
     elif handler == 'agent':
-        agent_log.error(payload, access_token)
+        agent_log.error(payload)
     elif handler == 'tornado':
         if TornadoAsyncHTTPClient is None:
             log.error('Unable to find tornado')


### PR DESCRIPTION
The underlying logging call is expecting:

```
logging.error(msg, *args, **kwars)
```

where `msg` is the message format string, and `args` are the arguments which should merged into msg using the string formatting operator.

All we want to do here is write msg to the agent log file, but in some cases the msg can contain invalid message formatting or unicode resulting in a `ValueError: unsupported format character` error.

It seems the format isn't interpreted if we don't pass arguments, and since the access_token already exists in msg, drop it.