### PR TITLE
more sophisticated exception message handling

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -625,12 +625,17 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
     raw_frames = traceback.extract_tb(trace)
     frames = [{'filename': f[0], 'lineno': f[1], 'method': f[2], 'code': f[3]} for f in raw_frames]
 
+    exc_message = getattr(exc, "message", None)
+    if exc_message is None:
+        exc_message = _transform(exc)
+    else:
+        exc_message = text(exc_message)
     data['body'] = {
         'trace': {
             'frames': frames,
             'exception': {
                 'class': cls.__name__,
-                'message': _transform(exc),
+                'message': exc_message,
             }
         }
     }

--- a/rollbar/test/contrib/flask/test_flask.py
+++ b/rollbar/test/contrib/flask/test_flask.py
@@ -36,7 +36,7 @@ def create_app():
     @app.route('/cause_error', methods=['GET', 'POST'])
     def cause_error():
         raise Exception("Uh oh")
-    
+
     @app.before_first_request
     def init_rollbar():
         rollbar.init(TOKEN, 'flasktest',
@@ -50,7 +50,7 @@ def create_app():
             return {'id': '123', 'username': 'testuser', 'email': 'test@example.com'}
 
     app.request_class = CustomRequest
-    
+
     return app
 
 if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
@@ -87,7 +87,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
+            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],
@@ -115,7 +115,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
+            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -127,7 +127,7 @@ class RollbarTest(BaseTest):
         self.assertIn('body', payload['data'])
         self.assertIn('trace', payload['data']['body'])
         self.assertIn('exception', payload['data']['body']['trace'])
-        self.assertEqual(payload['data']['body']['trace']['exception']['message'], str(type(Exception())))
+        self.assertEqual(payload['data']['body']['trace']['exception']['message'], 'foo')
         self.assertEqual(payload['data']['body']['trace']['exception']['class'], 'Exception')
 
         self.assertNotIn('args', payload['data']['body']['trace']['frames'][-1])


### PR DESCRIPTION
A recent fix for applying transforms to exception messages wasn't sophisticated enough to handle both the situations where there was a usable message and where there wasn't.  This handles the relevant cases.

@coryvirok @kshep 