### PR TITLE
revert exception safe repr

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -630,7 +630,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
             'frames': frames,
             'exception': {
                 'class': cls.__name__,
-                'message': _transform(exc),
+                'message': text(exc),
             }
         }
     }
@@ -864,7 +864,7 @@ def _add_locals_data(data, exc_info):
             # Fill in all of the named args
             for named_arg in named_args:
                 if named_arg in local_vars:
-                    args.append(_transform(local_vars[named_arg], key=(named_arg,)))
+                    args.append(local_vars[named_arg])
 
             # Add any varargs
             if arginfo.varargs is not None:

--- a/rollbar/test/contrib/flask/test_flask.py
+++ b/rollbar/test/contrib/flask/test_flask.py
@@ -36,7 +36,7 @@ def create_app():
     @app.route('/cause_error', methods=['GET', 'POST'])
     def cause_error():
         raise Exception("Uh oh")
-    
+
     @app.before_first_request
     def init_rollbar():
         rollbar.init(TOKEN, 'flasktest',
@@ -50,7 +50,7 @@ def create_app():
             return {'id': '123', 'username': 'testuser', 'email': 'test@example.com'}
 
     app.request_class = CustomRequest
-    
+
     return app
 
 if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
@@ -87,7 +87,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
+            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],
@@ -115,7 +115,7 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('body', data)
             self.assertEqual(data['body']['trace']['exception']['class'], 'Exception')
-            self.assertStringEqual(data['body']['trace']['exception']['message'], str(type(Exception('Uh oh'))))
+            self.assertStringEqual(data['body']['trace']['exception']['message'], 'Uh oh')
 
             self.assertIn('person', data)
             self.assertDictEqual(data['person'],

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -127,7 +127,7 @@ class RollbarTest(BaseTest):
         self.assertIn('body', payload['data'])
         self.assertIn('trace', payload['data']['body'])
         self.assertIn('exception', payload['data']['body']['trace'])
-        self.assertEqual(payload['data']['body']['trace']['exception']['message'], str(type(Exception())))
+        self.assertEqual(payload['data']['body']['trace']['exception']['message'], 'foo')
         self.assertEqual(payload['data']['body']['trace']['exception']['class'], 'Exception')
 
         self.assertNotIn('args', payload['data']['body']['trace']['frames'][-1])
@@ -743,27 +743,6 @@ class RollbarTest(BaseTest):
         called_with_frame = frames[1]
 
         self.assertEqual('changed', called_with_frame['args'][0])
-
-    @mock.patch('rollbar.send_payload')
-    def test_scrub_arg(self, send_payload):
-
-        def sensitive_call(username, password):
-            step1()
-
-        try:
-            sensitive_call('user', 'secret')
-        except:
-            rollbar.report_exc_info()
-
-        self.assertEqual(send_payload.called, True)
-
-        payload = json.loads(send_payload.call_args[0][0])
-        frames = payload['data']['body']['trace']['frames']
-        called_with_frame = frames[1]
-
-        self.assertEqual('user', called_with_frame['args'][0])
-        self.assertNotEqual('secret', called_with_frame['args'][1])
-        self.assertRegex(called_with_frame['args'][1], r'\*+')
 
     @mock.patch('rollbar.send_payload')
     def test_unicode_exc_info(self, send_payload):


### PR DESCRIPTION
This reverts a pull request we accepted and merged recently (https://github.com/rollbar/pyrollbar/pull/91).  It turns out that that request causes exception messages to not be passed along as expected,
and that isn't desired behavior.  We're going to attack this problem again soon and come up with a solution that meets the needs of the reverted pull request without causing the undesired side effects.

@coryvirok 