### PR TITLE
Don't die while serializing a stack trace if __repr__ throws

### DIFF
--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -75,21 +75,28 @@ class SerializableTransform(Transform):
         if o is None:
             return None
 
-        if any(filter(lambda x: isinstance(o, x), self.whitelist)):
-            try:
-                return repr(o)
-            except TypeError:
-                pass
+        # Best to be very careful when we call user code in the middle of
+        # preparing a stack trace. So we put a try/except around it all.
+        try:
+            if any(filter(lambda x: isinstance(o, x), self.whitelist)):
+                try:
+                    return repr(o)
+                except TypeError:
+                    pass
 
-        # If self.safe_repr is False, use repr() to serialize the object
-        if not self.safe_repr:
-            try:
-                return repr(o)
-            except TypeError:
-                pass
+            # If self.safe_repr is False, use repr() to serialize the object
+            if not self.safe_repr:
+                try:
+                    return repr(o)
+                except TypeError:
+                    pass
 
-        # Otherwise, just use the type name
-        return str(type(o))
+            # Otherwise, just use the type name
+            return str(type(o))
+
+        except Exception as e:
+            return '<%s in %s.__repr__: %s>' % (
+                e.__class__.__name__, o.__class__.__name__, str(e))
 
 
 __all__ = ['SerializableTransform']

--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -95,8 +95,13 @@ class SerializableTransform(Transform):
             return str(type(o))
 
         except Exception as e:
+            exc_str = ''
+            try:
+                exc_str = str(e)
+            except Exception as e2:
+                exc_str = '[%s while calling str(%s)]' % (e2.__class__.__name__, e.__class__.__name__)
             return '<%s in %s.__repr__: %s>' % (
-                e.__class__.__name__, o.__class__.__name__, str(e))
+                e.__class__.__name__, o.__class__.__name__, exc_str)
 
 
 __all__ = ['SerializableTransform']

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -218,3 +218,12 @@ class SerializableTransformTest(BaseTest):
         expected['custom'] = SNOWMAN
         self._assertSerialized(start, expected, whitelist=[CustomRepr])
 
+    def test_encode_with_bad_repr_doesnt_die(self):
+        class CustomRepr(object):
+            def __repr__(self):
+                assert False
+
+        start = {'hello': 'world', 'custom': CustomRepr()}
+        serializable = SerializableTransform(whitelist_types=[CustomRepr])
+        result = transforms.transform(start, [serializable])
+        self.assertRegex(result['custom'], "<AssertionError.*CustomRepr.*>")

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -227,3 +227,19 @@ class SerializableTransformTest(BaseTest):
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
         result = transforms.transform(start, [serializable])
         self.assertRegex(result['custom'], "<AssertionError.*CustomRepr.*>")
+
+    def test_encode_with_bad_str_doesnt_die(self):
+
+        class UnStringableException(Exception):
+            def __str__(self):
+                raise Exception('asdf')
+
+        class CustomRepr(object):
+
+            def __repr__(self):
+                raise UnStringableException()
+
+        start = {'hello': 'world', 'custom': CustomRepr()}
+        serializable = SerializableTransform(whitelist_types=[CustomRepr])
+        result = transforms.transform(start, [serializable])
+        self.assertRegex(result['custom'], "<UnStringableException.*Exception.*str.*>")


### PR DESCRIPTION
As discussed in #101.