### PR TITLE
argspec refactor + varargs scrubbing

### DIFF
--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -1,5 +1,3 @@
-import collections
-
 from rollbar.lib import python_major_version, binary_type, string_types, integer_types, traverse
 
 _ALLOWED_CIRCULAR_REFERENCE_TYPES = [binary_type, bool, type(None)]
@@ -58,48 +56,46 @@ class Transform(object):
         return self.default(o, key=key)
 
 
-
-def transform(obj, transforms, key=None):
+def transform(obj, transform, key=None):
     key = key or ()
 
-    def do_transforms(type_name, val, key=None, **kw):
-        for transform in transforms:
-            fn = getattr(transform, 'transform_%s' % type_name, transform.transform_custom)
-            val = fn(val, key=key, **kw)
+    def do_transform(type_name, val, key=None, **kw):
+        fn = getattr(transform, 'transform_%s' % type_name, transform.transform_custom)
+        val = fn(val, key=key, **kw)
 
         return val
 
     if python_major_version() < 3:
         def string_handler(s, key=None):
             if isinstance(s, str):
-                return do_transforms('py2_str', s, key=key)
+                return do_transform('py2_str', s, key=key)
             elif isinstance(s, unicode):
-                return do_transforms('unicode', s, key=key)
+                return do_transform('unicode', s, key=key)
     else:
         def string_handler(s, key=None):
             if isinstance(s, bytes):
-                return do_transforms('py3_bytes', s, key=key)
+                return do_transform('py3_bytes', s, key=key)
             elif isinstance(s, str):
-                return do_transforms('unicode', s, key=key)
+                return do_transform('unicode', s, key=key)
 
     def default_handler(o, key=None):
         if isinstance(o, integer_types + (float,)):
-            return do_transforms('number', o, key=key)
+            return do_transform('number', o, key=key)
 
         if isinstance(o, bool):
-            return do_transforms('boolean', o, key=key)
+            return do_transform('boolean', o, key=key)
 
-        return do_transforms('custom', o, key=key)
+        return do_transform('custom', o, key=key)
 
     handlers = {
         'string_handler': string_handler,
-        'tuple_handler': lambda o, key=None: do_transforms('tuple', o, key=key),
-        'namedtuple_handler': lambda o, key=None: do_transforms('namedtuple', o, key=key),
-        'list_handler': lambda o, key=None: do_transforms('list', o, key=key),
-        'set_handler': lambda o, key=None: do_transforms('set', o, key=key),
-        'mapping_handler': lambda o, key=None: do_transforms('dict', o, key=key),
-        'circular_reference_handler': lambda o, key=None, ref_key=None: \
-            do_transforms('circular_reference', o, key=key, ref_key=ref_key),
+        'tuple_handler': lambda o, key=None: do_transform('tuple', o, key=key),
+        'namedtuple_handler': lambda o, key=None: do_transform('namedtuple', o, key=key),
+        'list_handler': lambda o, key=None: do_transform('list', o, key=key),
+        'set_handler': lambda o, key=None: do_transform('set', o, key=key),
+        'mapping_handler': lambda o, key=None: do_transform('dict', o, key=key),
+        'circular_reference_handler': lambda o, key=None, ref_key=None:
+            do_transform('circular_reference', o, key=key, ref_key=ref_key),
         'default_handler': default_handler,
         'allowed_circular_reference_types': _ALLOWED_CIRCULAR_REFERENCE_TYPES
     }

--- a/rollbar/lib/transforms/scrub.py
+++ b/rollbar/lib/transforms/scrub.py
@@ -1,4 +1,3 @@
-import os
 import random
 
 from rollbar.lib import build_key_matcher, text

--- a/rollbar/lib/transforms/scrub_redact.py
+++ b/rollbar/lib/transforms/scrub_redact.py
@@ -1,0 +1,19 @@
+from rollbar.lib.transforms.scrub import ScrubTransform
+
+
+class RedactRef(object):
+    pass
+
+
+REDACT_REF = RedactRef()
+
+
+class ScrubRedactTransform(ScrubTransform):
+    def default(self, o, key=None):
+        if o is REDACT_REF:
+            return self.redact(o)
+
+        return super(ScrubRedactTransform, self).default(o, key=key)
+
+
+__all__ = ['ScrubRedactTransform']

--- a/rollbar/lib/transforms/scruburl.py
+++ b/rollbar/lib/transforms/scruburl.py
@@ -24,12 +24,9 @@ class ScrubUrlTransform(ScrubTransform):
         self.params_to_scrub = set(map(lambda x: x.lower(), params_to_scrub))
 
     def in_scrub_fields(self, key):
-        if not key:
-            # This can happen if the transform is applied to a non-object,
-            # like a string.
-            return True
-
-        return super(ScrubUrlTransform, self).in_scrub_fields(key)
+        # Returning True here because we want to scrub URLs out of
+        # every string, not just ones that we know the key for.
+        return True
 
     def redact(self, url_string):
         _redact = super(ScrubUrlTransform, self).redact
@@ -89,7 +86,6 @@ class ScrubUrlTransform(ScrubTransform):
             return super(ScrubUrlTransform, self).default(o, key=key)
 
         return o
-
 
 
 __all__ = ['ScrubUrlTransform']

--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -1,5 +1,3 @@
-import base64
-
 from rollbar.lib import binary_type, string_types
 from rollbar.lib import circular_reference_label, undecodable_object_label, unencodable_object_label
 from rollbar.lib import iteritems, python_major_version, text
@@ -69,7 +67,6 @@ class SerializableTransform(Transform):
             ret[new_k] = v
 
         return super(SerializableTransform, self).transform_dict(ret, key=key)
-
 
     def transform_custom(self, o, key=None):
         if o is None:

--- a/rollbar/test/test_scrub_redact_transform.py
+++ b/rollbar/test/test_scrub_redact_transform.py
@@ -1,0 +1,70 @@
+import collections
+import copy
+
+from rollbar.lib import text, transforms
+from rollbar.lib.transforms.scrub_redact import ScrubRedactTransform, REDACT_REF
+
+from rollbar.test import BaseTest
+
+
+class NotRedactRef():
+    pass
+
+NOT_REDACT_REF = NotRedactRef()
+
+try:
+    SCRUBBED = '*' * len(REDACT_REF)
+except:
+    SCRUBBED = '*' * len(text(REDACT_REF))
+
+
+class ScrubRedactTransformTest(BaseTest):
+    def _assertScrubbed(self, start, expected, redact_char='*', skip_id_check=False):
+        scrubber = ScrubRedactTransform(redact_char=redact_char, randomize_len=False)
+        result = transforms.transform(start, scrubber)
+
+        if not skip_id_check:
+            self.assertNotEqual(id(result), id(expected))
+
+        self.assertEqual(type(result), type(expected))
+
+        if isinstance(result, collections.Mapping):
+            self.assertDictEqual(result, expected)
+        elif isinstance(result, tuple):
+            self.assertTupleEqual(result, expected)
+        elif isinstance(result, list):
+            self.assertListEqual(result, expected)
+        elif isinstance(result, set):
+            self.assertSetEqual(result, expected)
+        else:
+            self.assertEqual(result, expected)
+
+    def test_no_scrub(self):
+        obj = NOT_REDACT_REF
+        expected = NOT_REDACT_REF
+        self._assertScrubbed(obj, expected, skip_id_check=True)
+
+    def test_scrub(self):
+        obj = REDACT_REF
+        expected = SCRUBBED
+        self._assertScrubbed(obj, expected)
+
+    def test_scrub_list(self):
+        obj = [REDACT_REF, REDACT_REF, REDACT_REF]
+        expected = [SCRUBBED, SCRUBBED, SCRUBBED]
+        self._assertScrubbed(obj, expected)
+
+    def test_scrub_set(self):
+        obj = set([REDACT_REF, NOT_REDACT_REF])
+        expected = set([SCRUBBED, NOT_REDACT_REF])
+        self._assertScrubbed(obj, expected)
+
+    def scrub_tuple(self):
+        obj = (REDACT_REF, REDACT_REF, REDACT_REF)
+        expected = (SCRUBBED, SCRUBBED, SCRUBBED)
+        self._assertScrubbed(obj, expected)
+
+    def test_scrub_dict(self):
+        obj = {'scrub_me': REDACT_REF}
+        expected = {'scrub_me': SCRUBBED}
+        self._assertScrubbed(obj, expected)

--- a/rollbar/test/test_scrub_transform.py
+++ b/rollbar/test/test_scrub_transform.py
@@ -10,7 +10,7 @@ from rollbar.test import BaseTest, SNOWMAN
 class ScrubTransformTest(BaseTest):
     def _assertScrubbed(self, suffixes, start, expected, redact_char='*', skip_id_check=False):
         scrubber = ScrubTransform(suffixes=suffixes, redact_char=redact_char, randomize_len=False)
-        result = transforms.transform(start, [scrubber])
+        result = transforms.transform(start, scrubber)
 
         """
         print start
@@ -145,7 +145,7 @@ class ScrubTransformTest(BaseTest):
         ref['circular'] = obj
 
         scrubber = ScrubTransform([])
-        result = transforms.transform(obj, [scrubber])
+        result = transforms.transform(obj, scrubber)
 
         self.assertIsNot(result, obj)
         self.assertIsNot(result['password'], ref)
@@ -176,4 +176,3 @@ class ScrubTransformTest(BaseTest):
             'password': '***'
         }
         self._assertScrubbed([['password']], obj, expected)
-

--- a/rollbar/test/test_scruburl_transform.py
+++ b/rollbar/test/test_scruburl_transform.py
@@ -26,13 +26,7 @@ class ScrubUrlTransformTest(BaseTest):
                                      scrub_password=scrub_password,
                                      redact_char=redact_char,
                                      randomize_len=False)
-        result = transforms.transform(start, [scrubber])
-
-        """
-        print(start)
-        print(result)
-        print(expected)
-        """
+        result = transforms.transform(start, scrubber)
 
         if not skip_id_check:
             self.assertNotEqual(id(result), id(expected))
@@ -123,16 +117,18 @@ class ScrubUrlTransformTest(BaseTest):
 
     def test_scrub_dict_val_isnt_string(self):
 
-        # This link will *not* be scrubbed because the value isn't a string or bytes
+        url = 'cory:secr3t@foo.com/asdf?password=secret&clear=text'
+
+        # Every string which is a URL should be scrubbed
         obj = {
-            'url': ['cory:secr3t@foo.com/asdf?password=secret&clear=text']
+            'url': [url]
         }
 
         scrubber = ScrubUrlTransform(suffixes=[('url',)], params_to_scrub=['password'], randomize_len=False)
-        result = transforms.transform(obj, [scrubber])
+        result = transforms.transform(obj, scrubber)
 
-        expected = copy.deepcopy(obj)
-        self.assertDictEqual(expected, result)
+        expected = url.replace('secr3t', '------').replace('secret', '------')
+        self._assertScrubbed(['password'], result['url'][0], expected)
 
     def test_scrub_dict_nested_key_match_with_circular_ref(self):
         # If a URL is a circular reference then let's make sure to
@@ -144,7 +140,7 @@ class ScrubUrlTransformTest(BaseTest):
         }
 
         scrubber = ScrubUrlTransform(suffixes=[('url',), ('link',)], params_to_scrub=['password'], randomize_len=False)
-        result = transforms.transform(obj, [scrubber])
+        result = transforms.transform(obj, scrubber)
 
         self.assertNotIn('secr3t', result['url'][0]['link'])
         self.assertNotIn('secret', result['url'][0]['link'])

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -26,7 +26,7 @@ undecodable_repr = '<Undecodable type:(%s) base64:(%s)>' % (binary_type_name, in
 class SerializableTransformTest(BaseTest):
     def _assertSerialized(self, start, expected, safe_repr=True, whitelist=None, skip_id_check=False):
         serializable = SerializableTransform(safe_repr=safe_repr, whitelist_types=whitelist)
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
 
         """
         #print start
@@ -88,7 +88,7 @@ class SerializableTransformTest(BaseTest):
         start = float('nan')
 
         serializable = SerializableTransform()
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
 
         self.assertTrue(math.isnan(result))
 
@@ -96,7 +96,7 @@ class SerializableTransformTest(BaseTest):
         start = float('inf')
 
         serializable = SerializableTransform()
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
 
         self.assertTrue(math.isinf(result))
 
@@ -190,7 +190,7 @@ class SerializableTransformTest(BaseTest):
         start = {'hello': 'world', 'custom': CustomRepr()}
 
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
 
         if python_major_version() < 3:
             self.assertEqual(result['custom'], b'hello')
@@ -205,7 +205,7 @@ class SerializableTransformTest(BaseTest):
         start = {'hello': 'world', 'custom': CustomRepr()}
 
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
         self.assertRegex(result['custom'], "<class '.*CustomRepr'>")
 
     def test_encode_with_custom_repr_returns_unicode(self):
@@ -225,7 +225,7 @@ class SerializableTransformTest(BaseTest):
 
         start = {'hello': 'world', 'custom': CustomRepr()}
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
         self.assertRegex(result['custom'], "<AssertionError.*CustomRepr.*>")
 
     def test_encode_with_bad_str_doesnt_die(self):
@@ -241,5 +241,5 @@ class SerializableTransformTest(BaseTest):
 
         start = {'hello': 'world', 'custom': CustomRepr()}
         serializable = SerializableTransform(whitelist_types=[CustomRepr])
-        result = transforms.transform(start, [serializable])
+        result = transforms.transform(start, serializable)
         self.assertRegex(result['custom'], "<UnStringableException.*Exception.*str.*>")


### PR DESCRIPTION
#### Interesting Changes
* payload changes
  * `argspec` has replaced `args` in the frame payload and contains only argument names
  * `varargspec` is now the frame payload and contains the variable name for varargs
  * `keywordspec` is now in the frame payload and contains the variable name for keywords
* We used to remove arguments with default values from args and put them into kwargs in the payload. No longer doing that here. In fact, kwargs has been removed entirely as it was already in locals.
* varargs are now scrubbed by default