### PR TITLE
improved handling of NaN and (Negative)Infinity

### DIFF
--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -181,6 +181,17 @@ def circular_reference_label(data, ref_key=None):
     return '<CircularReference type:(%s) ref:(%s)>' % (type(data).__name__, ref)
 
 
+def float_nan_label(data):
+    return '<NaN>'
+
+
+def float_infinity_label(data):
+    if data > 1:
+        return '<Infinity>'
+    else:
+        return '<NegativeInfinity>'
+
+
 def unencodable_object_label(data):
     return '<Unencodable type:(%s) base64:(%s)>' % (type(data).__name__,
                                                     base64.b64encode(data).decode('ascii'))
@@ -189,4 +200,3 @@ def unencodable_object_label(data):
 def undecodable_object_label(data):
     return '<Undecodable type:(%s) base64:(%s)>' % (type(data).__name__,
                                                     base64.b64encode(data).decode('ascii'))
-

--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -1,5 +1,7 @@
+import math
+
 from rollbar.lib import binary_type, string_types
-from rollbar.lib import circular_reference_label, undecodable_object_label, unencodable_object_label
+from rollbar.lib import circular_reference_label, float_infinity_label, float_nan_label, undecodable_object_label, unencodable_object_label
 from rollbar.lib import iteritems, python_major_version, text
 
 from rollbar.lib.transforms import Transform
@@ -22,6 +24,14 @@ class SerializableTransform(Transform):
             new_vals.append(transformed_dict[field])
 
         return '<%s>' % text(o._make(new_vals))
+
+    def transform_number(self, o, key=None):
+        if math.isnan(o):
+            return float_nan_label(o)
+        elif math.isinf(o):
+            return float_infinity_label(o)
+        else:
+            return o
 
     def transform_py2_str(self, o, key=None):
         try:

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -60,13 +60,6 @@ class ShortenerTransform(Transform):
         if obj is None:
             return None
 
-        if isinstance(obj, float):
-            if math.isinf(obj):
-                return 'Infinity'
-
-            if math.isnan(obj):
-                return 'NaN'
-
         if self.safe_repr:
             obj = text(obj)
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -677,6 +677,7 @@ class RollbarTest(BaseTest):
     def test_scrub_nans(self, send_payload):
         def _raise():
             infinity = float('Inf')
+            negative_infinity = float('-Inf')
             not_a_number = float('NaN')
             raise Exception()
 
@@ -689,8 +690,9 @@ class RollbarTest(BaseTest):
 
         payload = json.loads(send_payload.call_args[0][0])
 
-        self.assertEqual('Infinity', payload['data']['body']['trace']['frames'][-1]['locals']['infinity'])
-        self.assertEqual('NaN', payload['data']['body']['trace']['frames'][-1]['locals']['not_a_number'])
+        self.assertEqual('<Infinity>', payload['data']['body']['trace']['frames'][-1]['locals']['infinity'])
+        self.assertEqual('<NegativeInfinity>', payload['data']['body']['trace']['frames'][-1]['locals']['negative_infinity'])
+        self.assertEqual('<NaN>', payload['data']['body']['trace']['frames'][-1]['locals']['not_a_number'])
 
     @mock.patch('rollbar.send_payload')
     def test_scrub_self_referencing(self, send_payload):

--- a/rollbar/test/test_serializable_transform.py
+++ b/rollbar/test/test_serializable_transform.py
@@ -79,26 +79,25 @@ class SerializableTransformTest(BaseTest):
         expected = 3.14
         self._assertSerialized(start, expected, skip_id_check=True)
 
+    def test_encode_float_nan(self):
+        start = float('nan')
+        expected = '<NaN>'
+        self._assertSerialized(start, expected, skip_id_check=True)
+
+    def test_encode_float_infinity(self):
+        start = float('inf')
+        expected = '<Infinity>'
+        self._assertSerialized(start, expected, skip_id_check=True)
+
+    def test_encode_float_neg_infinity(self):
+        start = float('-inf')
+        expected = '<NegativeInfinity>'
+        self._assertSerialized(start, expected, skip_id_check=True)
+
     def test_encode_int(self):
         start = 33
         expected = 33
         self._assertSerialized(start, expected, skip_id_check=True)
-
-    def test_encode_NaN(self):
-        start = float('nan')
-
-        serializable = SerializableTransform()
-        result = transforms.transform(start, serializable)
-
-        self.assertTrue(math.isnan(result))
-
-    def test_encode_Infinity(self):
-        start = float('inf')
-
-        serializable = SerializableTransform()
-        result = transforms.transform(start, serializable)
-
-        self.assertTrue(math.isinf(result))
 
     def test_encode_empty_tuple(self):
         start = ()


### PR DESCRIPTION
Improve handling of NaN and (Negative)Infinity by serializing them into strings. It turns out these values are not part of RFC 4627! Who knew?