### PR TITLE
fix failsafe function

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1227,7 +1227,7 @@ def _send_failsafe(message, uuid, host):
     payload = _build_payload(data)
 
     try:
-        send_payload(payload, SETTINGS['access_token'], uuid, host)
+        send_payload(payload, SETTINGS['access_token'])
     except Exception:
         log.exception('Rollbar: Error sending failsafe.')
 


### PR DESCRIPTION
It seems we were using the wrong number of arguments to `send_payload`. Likely didn't get picked up by unit tests since we were patching that very function!