### PR TITLE
put record msg and args in history, remove message

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -161,7 +161,8 @@ class RollbarHandler(logging.Handler):
 
     def _build_history_data(self, record):
         data = {'timestamp': record.created,
-                'message': record.getMessage()}
+                'format': record.msg,
+                'args': record.args}
 
         if hasattr(record, 'rollbar_uuid'):
             data['uuid'] = record.rollbar_uuid


### PR DESCRIPTION
Addresses #134.

Python's logging module can throw `UnicodeDecodeError`s when the [getMessage](https://docs.python.org/2/library/logging.html#logging.LogRecord.getMessage) function attempts to format the log message. This can happen for a few reasons but it's almost always caused by a mismatch between encodings (ASCII vs UTF-8) and string types (`str` vs `unicode`) (see #134 for examples). For reference, the source for `getMessage` is as follows:

```python
def getMessage(self):
    """
    Return the message for this LogRecord.

    Return the message for this LogRecord after merging any user-supplied
    arguments with the message.
    """
    if not _unicode: #if no unicode support...
        msg = str(self.msg)
    else:
        msg = self.msg
        if not isinstance(msg, basestring):
            try:
                msg = str(self.msg)
            except UnicodeError:
                msg = self.msg      #Defer encoding till later
    if self.args:
        msg = msg % self.args
    return msg
```

Pyrollbar's log handler stores the last few log records in thread locals to give the user some additional context to their log messages. When building a payload to send to Rollbar, getMessage is called on each record in the history in order to format the record's message.

However, records that cause exceptions when attempting to format can end up stored in pyrollbar's history. Additionally, because of where the exception occurs, the record is never purged from the history. This results in an exception every time a user tries to log because `getMessage` is called on the bad record.

We currently don't use the history data in Rollbar's UI other than just displaying it raw. Knowing this, a simple and safe fix is to store the unformatted record message and args instead of the formatted message.