### PR TITLE
Fixed an assignment issue

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1253,12 +1253,12 @@ def _parse_response(path, access_token, params, resp, endpoint=None):
             payload = json.loads(params)
             uuid = payload['data']['uuid']
             host = payload['data']['server']['host']
+            log.error("Rollbar: request entity too large for UUID %r\n. Payload:\n%r", uuid, payload)
         except (TypeError, ValueError):
             log.exception('Unable to decode JSON for failsafe.')
         except KeyError:
             log.exception('Unable to find payload parameters for failsafe.')
 
-        log.error("Rollbar: request entity too large for UUID %r\n. Payload:\n%r", uuid, payload)
         _send_failsafe('payload too large', uuid, host)
     elif resp.status_code != 200:
         log.warning("Got unexpected status code from Rollbar api: %s\nResponse:\n%s",


### PR DESCRIPTION
Here is the stack trace of an error I got in my environment:

```
[05/Oct/2016 11:31:03][ERROR][rollbar][__init__.py:_send_payload:1097] Exception while posting item UnboundLocalError("local variable 'payload' referenced before assignment",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/rollbar/__init__.py", line 1095, in _send_payload
    _post_api('item/', payload, access_token=access_token)
  File "/usr/local/lib/python2.7/dist-packages/rollbar/__init__.py", line 1138, in _post_api
    return _parse_response(path, SETTINGS['access_token'], payload, resp)
  File "/usr/local/lib/python2.7/dist-packages/rollbar/__init__.py", line 1261, in _parse_response
    log.error("Rollbar: request entity too large for UUID %r\n. Payload:\n%r", uuid, payload)
UnboundLocalError: local variable 'payload' referenced before assignment
```

The `payload = json.loads(params)` generated a ValueError, which got caught in the first `except`. But the `log.error` failed since the `payload` variable was never assigned.

My solution is to do the `log.error` inside the try block.