### PR TITLE
Change _check_config() to deal with agent handler

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -648,9 +648,11 @@ def _check_config():
         return False
 
     # make sure we have an access_token
-    if not SETTINGS.get('access_token'):
-        log.warning("pyrollbar: No access_token provided. Please configure by calling rollbar.init() with your access token.")
-        return False
+    handler = SETTINGS.get('handler')
+    if not handler == 'agent':
+        if not SETTINGS.get('access_token'):
+            log.warning("pyrollbar: No access_token provided. Please configure by calling rollbar.init() with your access token.")
+            return False
 
     return True
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -652,7 +652,6 @@ def _check_config():
         return True
 
     # make sure we have an access_token
-    handler = SETTINGS.get('handler')
     if not SETTINGS.get('access_token'):
         log.warning("pyrollbar: No access_token provided. Please configure by calling rollbar.init() with your access token.")
         return False

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -647,12 +647,15 @@ def _check_config():
         log.info("pyrollbar: Not reporting because rollbar is disabled.")
         return False
 
+    # skip access token check for the agent handler
+    if SETTINGS.get('handler') == 'agent':
+        return True
+
     # make sure we have an access_token
     handler = SETTINGS.get('handler')
-    if not handler == 'agent':
-        if not SETTINGS.get('access_token'):
-            log.warning("pyrollbar: No access_token provided. Please configure by calling rollbar.init() with your access token.")
-            return False
+    if not SETTINGS.get('access_token'):
+        log.warning("pyrollbar: No access_token provided. Please configure by calling rollbar.init() with your access token.")
+        return False
 
     return True
 


### PR DESCRIPTION
_check_config() checks the configuration for sanity before processing
but requires every handler to have an access_token. When the handler
is an agent we shouldn't need the access_token because it is set on
the rollbar-agent.