### PR TITLE
Update scrub_fields documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Default: `thread`
 </dd>
 <dt>scrub_fields
 </dt>
-<dd>List of sensitive field names to scrub out of request params and locals. Values will be replaced with asterisks. If overriding, make sure to list all fields you want to scrub, not just fields you want to add to the default. Param names are converted to lowercase before comparing against the scrub list.
+<dd>Any field with a suffix appearing in this array will be scrubbed out of request params and locals. Its value will be replaced with a random number of asterisks. If overriding, make sure to list all fields you want to scrub, not just fields you want to add to the default. Param names are converted to lowercase before comparing against the scrub list.
 
 Default: `['pw', 'passwd', 'password', 'secret', 'confirm_password', 'confirmPassword', 'password_confirmation', 'passwordConfirmation', 'access_token', 'auth', 'authentication']`
 


### PR DESCRIPTION
From reading the code, it appears that the scrub_fields transformer uses suffix matching, not whole-field matching. This updates the documentation to reflect that. (This is important to us so we can have e.g. a convention of suffixing our secret variables with _secret to get them scrubbed!)