### PR TITLE
Add request.method to pyrollbar errors

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -922,6 +922,7 @@ def _build_webob_request_data(request):
         'GET': dict(request.GET),
         'user_ip': _extract_user_ip(request),
         'headers': dict(request.headers),
+        'method': request.method,
     }
 
     try:


### PR DESCRIPTION
Tested in dev via Pshell using the built-in request - not sure what further testing this might need, if any.