### PR TITLE
Report exception causes

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -609,10 +609,10 @@ def _walk_trace_chain(cls, exc, trace):
     trace_chain = [_trace_data(cls, exc, trace)]
 
     while True:
-        exc = getattr(exc, '__cause__') or getattr(exc, '__context__')
+        exc = getattr(exc, '__cause__', None) or getattr(exc, '__context__', None)
         if not exc:
             break
-        trace_chain.append(_trace_data(type(exc), exc, getattr(exc, '__traceback__')))
+        trace_chain.append(_trace_data(type(exc), exc, getattr(exc, '__traceback__', None)))
 
     return trace_chain
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -144,7 +144,11 @@ class RollbarTest(BaseTest):
         def _raise():
             cause = CauseException('bar')
             try:
-                raise Exception('foo') from cause
+                # in python3 this would normally be expressed as
+                # raise Exception('foo') from cause
+                e = Exception('foo')
+                setattr(e, '__cause__', cause)  # PEP-3134
+                raise e
             except:
                 rollbar.report_exc_info()
 
@@ -172,13 +176,14 @@ class RollbarTest(BaseTest):
     def test_report_exception_with_context(self, send_payload):
 
         def _raise():
+            context = CauseException('bar')
             try:
-                raise CauseException('bar')
+                # in python3 __context__ is automatically set when an exception is raised in an except block
+                e = Exception('foo')
+                setattr(e, '__context__', context)  # PEP-3134
+                raise e
             except:
-                try:
-                    raise Exception('foo')
-                except:
-                    rollbar.report_exc_info()
+                rollbar.report_exc_info()
 
         _raise()
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -5,6 +5,8 @@ import mock
 import socket
 import uuid
 
+import sys
+
 try:
     from StringIO import StringIO
 except ImportError:
@@ -148,6 +150,10 @@ class RollbarTest(BaseTest):
             try:
                 _raise_cause()
             except CauseException as cause:
+                # python2 won't automatically assign this traceback...
+                exc_info = sys.exc_info()
+                setattr(cause, '__traceback__', exc_info[2])
+
                 try:
                     foo_local = 'foo'
                     # in python3 this would normally be expressed as
@@ -190,6 +196,10 @@ class RollbarTest(BaseTest):
             try:
                 _raise_context()
             except CauseException as context:
+                # python2 won't automatically assign this traceback...
+                exc_info = sys.exc_info()
+                setattr(context, '__traceback__', exc_info[2])
+
                 try:
                     foo_local = 'foo'
                     # in python3 __context__ is automatically set when an exception is raised in an except block


### PR DESCRIPTION
This adds exception causes/contexts (as defined in [PEP-3134](https://www.python.org/dev/peps/pep-3134/)) to the payload sent to rollbar.

The structure of the payload is based on the [rollbar-gem](https://github.com/rollbar/rollbar-gem/commit/293199601341dc7c7bfe866047afd9cd3fd69f7f) implementation. If the reported exception has no `__cause__` or `__context__`, it's sent in `data['body']['trace']`; if it does, the entire cause chain is sent in `data['body']['trace_chain']`. As in the Ruby implementation, usage of `trace` and `trace_chain` are mutually exclusive.

Fixes #151 
