### PR TITLE
Add 'shortener_keys' to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,31 @@ Default: `True`
 </dt>
 <dd>If `True`, network requests will fail unless encountering a valid certificate. Default `True`.
 </dd>
+<dt>shortener_keys
+</dt>
+<dd>A list of key prefixes (as tuple) to apply our shortener transform to. Added to built-in list:
+
+```
+[
+    ('body', 'request', 'POST'),
+    ('body', 'request', 'json')
+]
+```
+
+If `locals.enabled` is `True`, extra keys are also automatically added:
+
+```
+[
+    ('body', 'trace', 'frames', '*', 'code'),
+    ('body', 'trace', 'frames', '*', 'args', '*'),
+    ('body', 'trace', 'frames', '*', 'kwargs', '*'),
+    ('body', 'trace', 'frames', '*', 'locals', '*')
+]
+```
+
+Default: `[]`
+
+</dd>
 </dd>
 </dl>
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -236,7 +236,8 @@ SETTINGS = {
         'sizes': DEFAULT_LOCALS_SIZES,
         'whitelisted_types': []
     },
-    'verify_https': True
+    'verify_https': True,
+    'shortener_keys': []
 }
 
 # Set in init()
@@ -319,6 +320,8 @@ def init(access_token, environment='production', **kw):
         shortener_keys.append(('body', 'trace', 'frames', '*', 'args', '*'))
         shortener_keys.append(('body', 'trace', 'frames', '*', 'kwargs', '*'))
         shortener_keys.append(('body', 'trace', 'frames', '*', 'locals', '*'))
+
+    shortener_keys.extend(SETTINGS['shortener_keys'])
 
     shortener = ShortenerTransform(safe_repr=SETTINGS['locals']['safe_repr'],
                                    keys=shortener_keys,


### PR DESCRIPTION
Allow to specify additional shortener keys, in order to shorten dict values (e.g. in `locals`)