### PR TITLE
Remove Django request body from payload. It can contain sensitive data.

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -966,11 +966,6 @@ def _build_django_request_data(request):
         'user_ip': _wsgi_extract_user_ip(request.environ),
     }
 
-    try:
-        request_data['body'] = request.body
-    except:
-        pass
-
     request_data['headers'] = _extract_wsgi_headers(request.environ.items())
 
     return request_data


### PR DESCRIPTION
Post requests can include sensitive data in the request body. Sensitive POST params can be scrubbed from the `request.POST` attributes but not from the request body itself.

I think this works for other frameworks (werkzeug, bottle) because the body is only included if it's JSON and can then be scrubbed, but the django body is just a string.