### PR TITLE
Adjust request params shortened by default and add shortener tests

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -309,8 +309,12 @@ def init(access_token, environment='production', **kw):
         ScrubUrlTransform(suffixes=[(field,) for field in SETTINGS['url_fields']], params_to_scrub=SETTINGS['scrub_fields'])
     ]
 
-    # A list of key prefixes to apply our shortener transform to
+    # A list of key prefixes to apply our shortener transform to. The request
+    # being included in the body key is old behavior and is being retained for
+    # backwards compatibility.
     shortener_keys = [
+        ('request', 'POST'),
+        ('request', 'json'),
         ('body', 'request', 'POST'),
         ('body', 'request', 'json'),
     ]

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -3,6 +3,7 @@ import collections
 import copy
 import os
 import sys
+from array import array
 
 import six
 from six.moves import urllib
@@ -14,7 +15,7 @@ binary_type = six.binary_type
 integer_types = six.integer_types
 number_types = integer_types + (float, )
 string_types = six.string_types
-sequence_types = (collections.Mapping, list, tuple, set, collections.deque)
+sequence_types = (collections.Mapping, list, tuple, set, frozenset, array, collections.deque)
 
 urlparse = urllib.parse.urlparse
 urlsplit = urllib.parse.urlsplit

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -55,7 +55,7 @@ class ShortenerTransform(Transform):
         if len(val) <= max_len:
             return obj
 
-        return self._repr.repr(val)
+        return self._repr.repr(obj)
 
     def _shorten_other(self, obj):
         if obj is None:

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -45,7 +45,7 @@ class ShortenerTransformTest(BaseTest):
         if key == 'dict':
             self.assertEqual(expected, result[key].count(':'))
         elif key == 'other':
-            self.assertTrue(result[key].startswith(expected))
+            self.assertIn(expected, result[key])
         else:
             self.assertEqual(expected, result[key])
 
@@ -100,6 +100,5 @@ class ShortenerTransformTest(BaseTest):
         self._assert_shortened('deque', expected)
 
     def test_shorten_other(self):
-        expected = ("u'<rollbar.test.test_shortener_transform.TestCla..."
-                    "eryVeryVeryVeryLongName instance at")
+        expected = '<rollbar.test.test_shortener_transform.TestCla...'
         self._assert_shortened('other', expected)

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -54,9 +54,10 @@ class ShortenerTransformTest(BaseTest):
         else:
             self.assertEqual(expected, stripped_result_key)
 
-        # result.pop(key)
-        # self.data.pop(key)
-        # self.assertEqual(result, self.data)
+        # make sure nothing else was shortened
+        result.pop(key)
+        self.assertNotIn('...', str(result))
+        self.assertNotIn('...', str(self.data))
 
     def test_no_shorten(self):
         shortener = ShortenerTransform(**DEFAULT_LOCALS_SIZES)

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -42,12 +42,15 @@ class ShortenerTransformTest(BaseTest):
         shortener = ShortenerTransform(keys=[(key,)], **DEFAULT_LOCALS_SIZES)
         result = transforms.transform(self.data, shortener)
 
+        # the repr output can vary between Python versions
+        stripped_result_key = result[key].strip("'\"u")
+
         if key == 'dict':
-            self.assertEqual(expected, result[key].count(':'))
+            self.assertEqual(expected, stripped_result_key.count(':'))
         elif key == 'other':
-            self.assertIn(expected, result[key])
+            self.assertIn(expected, stripped_result_key)
         else:
-            self.assertEqual(expected, result[key])
+            self.assertEqual(expected, stripped_result_key)
 
         result.pop(key)
         self.data.pop(key)
@@ -59,7 +62,7 @@ class ShortenerTransformTest(BaseTest):
         self.assertEqual(self.data, result)
 
     def test_shorten_string(self):
-        expected = "'{}...{}'".format('x'*47, 'x'*48)
+        expected = '{}...{}'.format('x'*47, 'x'*48)
         self._assert_shortened('string', expected)
 
     def test_shorten_long(self):
@@ -84,15 +87,11 @@ class ShortenerTransformTest(BaseTest):
         self._assert_shortened('set', expected)
 
     def test_shorten_frozenset(self):
-        # XXX(eric): this probably isn't doing what we expected
-        # expected = 'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
-        expected = "u'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])'"
+        expected = 'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
         self._assert_shortened('frozenset', expected)
 
     def test_shorten_array(self):
-        # XXX(eric): this probably isn't doing what we expected
-        # expected = 'array(\'l\', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
-        expected = 'u"array(\'l\', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])"'
+        expected = 'array(\'l\', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
         self._assert_shortened('array', expected)
 
     def test_shorten_deque(self):

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -1,6 +1,8 @@
+import sys
 from array import array
 from collections import deque
 
+import six
 from rollbar import DEFAULT_LOCALS_SIZES
 from rollbar.lib import transforms
 from rollbar.lib.transforms.shortener import ShortenerTransform
@@ -52,9 +54,9 @@ class ShortenerTransformTest(BaseTest):
         else:
             self.assertEqual(expected, stripped_result_key)
 
-        result.pop(key)
-        self.data.pop(key)
-        self.assertEqual(result, self.data)
+        # result.pop(key)
+        # self.data.pop(key)
+        # self.assertEqual(result, self.data)
 
     def test_no_shorten(self):
         shortener = ShortenerTransform(**DEFAULT_LOCALS_SIZES)
@@ -67,6 +69,8 @@ class ShortenerTransformTest(BaseTest):
 
     def test_shorten_long(self):
         expected = '179556827339164684...002504519623752387L'
+        if six.PY3:
+            expected = '179556827339164684...5002504519623752387'
         self._assert_shortened('long', expected)
 
     def test_shorten_mapping(self):
@@ -84,10 +88,14 @@ class ShortenerTransformTest(BaseTest):
 
     def test_shorten_set(self):
         expected = 'set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        if sys.version_info >= (3, 5):
+            expected = '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...}'
         self._assert_shortened('set', expected)
 
     def test_shorten_frozenset(self):
         expected = 'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        if sys.version_info >= (3, 5):
+            expected = 'frozenset({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...})'
         self._assert_shortened('frozenset', expected)
 
     def test_shorten_array(self):
@@ -96,8 +104,12 @@ class ShortenerTransformTest(BaseTest):
 
     def test_shorten_deque(self):
         expected = 'deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        if sys.version_info >= (3, 5):
+            expected = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]'
         self._assert_shortened('deque', expected)
 
     def test_shorten_other(self):
         expected = '<rollbar.test.test_shortener_transform.TestCla...'
+        if six.PY3:
+            expected = '<rollbar.test.test_shortener_transform.TestClas...'
         self._assert_shortened('other', expected)

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -63,8 +63,7 @@ class ShortenerTransformTest(BaseTest):
         self._assert_shortened('string', expected)
 
     def test_shorten_long(self):
-        # XXX(eric): this probably isn't doing what we expected
-        expected = "u'17955682733916468498414734863645002504519623752387'"
+        expected = '179556827339164684...002504519623752387L'
         self._assert_shortened('long', expected)
 
     def test_shorten_mapping(self):

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -1,0 +1,106 @@
+from array import array
+from collections import deque
+
+from rollbar import DEFAULT_LOCALS_SIZES
+from rollbar.lib import transforms
+from rollbar.lib.transforms.shortener import ShortenerTransform
+from rollbar.test import BaseTest
+
+
+class TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName:
+    pass
+
+
+class ShortenerTransformTest(BaseTest):
+    def setUp(self):
+        self.data = {
+            'string': 'x' * 120,
+            'long': 17955682733916468498414734863645002504519623752387,
+            'dict': {
+                'one': 'one',
+                'two': 'two',
+                'three': 'three',
+                'four': 'four',
+                'five': 'five',
+                'six': 'six',
+                'seven': 'seven',
+                'eight': 'eight',
+                'nine': 'nine',
+                'ten': 'ten',
+                'eleven': 'eleven'
+            },
+            'list': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            'tuple': (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+            'set': set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            'frozenset': frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            'array': array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            'deque': deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 15),
+            'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName()
+        }
+
+    def _assert_shortened(self, key, expected):
+        shortener = ShortenerTransform(keys=[(key,)], **DEFAULT_LOCALS_SIZES)
+        result = transforms.transform(self.data, shortener)
+
+        if key == 'dict':
+            self.assertEqual(expected, result[key].count(':'))
+        elif key == 'other':
+            self.assertTrue(result[key].startswith(expected))
+        else:
+            self.assertEqual(expected, result[key])
+
+        result.pop(key)
+        self.data.pop(key)
+        self.assertEqual(result, self.data)
+
+    def test_no_shorten(self):
+        shortener = ShortenerTransform(**DEFAULT_LOCALS_SIZES)
+        result = transforms.transform(self.data, shortener)
+        self.assertEqual(self.data, result)
+
+    def test_shorten_string(self):
+        expected = "'{}...{}'".format('x'*47, 'x'*48)
+        self._assert_shortened('string', expected)
+
+    def test_shorten_long(self):
+        # XXX(eric): this probably isn't doing what we expected
+        expected = "u'17955682733916468498414734863645002504519623752387'"
+        self._assert_shortened('long', expected)
+
+    def test_shorten_mapping(self):
+        # here, expected is the number of key value pairs
+        expected = 10
+        self._assert_shortened('dict', expected)
+
+    def test_shorten_list(self):
+        expected = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]'
+        self._assert_shortened('list', expected)
+
+    def test_shorten_tuple(self):
+        expected = '(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...)'
+        self._assert_shortened('tuple', expected)
+
+    def test_shorten_set(self):
+        expected = 'set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        self._assert_shortened('set', expected)
+
+    def test_shorten_frozenset(self):
+        # XXX(eric): this probably isn't doing what we expected
+        # expected = 'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        expected = "u'frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])'"
+        self._assert_shortened('frozenset', expected)
+
+    def test_shorten_array(self):
+        # XXX(eric): this probably isn't doing what we expected
+        # expected = 'array(\'l\', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        expected = 'u"array(\'l\', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])"'
+        self._assert_shortened('array', expected)
+
+    def test_shorten_deque(self):
+        expected = 'deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
+        self._assert_shortened('deque', expected)
+
+    def test_shorten_other(self):
+        expected = ("u'<rollbar.test.test_shortener_transform.TestCla..."
+                    "eryVeryVeryVeryLongName instance at")
+        self._assert_shortened('other', expected)


### PR DESCRIPTION
`request` lives at the top level of the payload these days