### PR TITLE
handle the case where sys.exc_info returns (None, None, None) gracefully

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -633,7 +633,7 @@ def _trace_data(cls, exc, trace):
     trace_data = {
         'frames': frames,
         'exception': {
-            'class': cls.__name__,
+            'class': getattr(cls, '__name__', cls.__class__.__name__),
             'message': text(exc),
         }
     }

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -320,6 +320,15 @@ class RollbarTest(BaseTest):
         payload = json.loads(send_payload.call_args[0][0])
         self.assertEqual(payload['data']['level'], 'warn')
 
+    @mock.patch('rollbar.send_payload')
+    def test_report_exc_info_nones(self, send_payload):
+
+        rollbar.report_exc_info(exc_info=(None, None, None))
+
+        self.assertEqual(send_payload.called, True)
+        payload = json.loads(send_payload.call_args[0][0])
+        self.assertEqual(payload['data']['level'], 'error')
+
     @mock.patch('rollbar._send_failsafe')
     @mock.patch('rollbar.lib.transport.post',
                 side_effect=lambda *args, **kw: MockResponse({'status': 'Payload Too Large'}, 413))


### PR DESCRIPTION
Fixes #14

I noticed this old issue hanging around and it sounded stupid that we don't handle that edge case. It turns out that almost everything can handle the case except for one line. And in that one case we know that `cls` is None so that `cls.__class__.__name__` will be `NoneType`. So we still report an exception to rollbar in this case along with any extra data that might have been added to the log call, but it will have Nones in some places.