### PR TITLE
make a decorator for lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,62 @@ Be sure to replace ```POST_SERVER_ITEM_ACCESS_TOKEN``` with your project's ```po
 
 Check out the [Twisted example](https://github.com/rollbar/pyrollbar/tree/master/rollbar/examples/twisted).
 
+### AWS Lambda
+
+The biggest issue with the Lambda execution environment is that as soon as you
+return from your handler function, any work executing in other threads will
+stop executing as the process is frozen. This is true also of any child
+processes that one may spawn. Furthermore, the Lambda environment implements
+multithreading via a hypervisor on a single CPU core. Therefore, using
+separate threads to do additional work will not necessarily lead to better
+performance.
+
+In order to ensure that the Rollbar library works correctly, meaning that items
+are transmitted to the Rollbar API, one must not return from the main handler
+function before all of this work completes. In order to ensure this, one can
+either use the `blocking` handler by specifying this value in the configuration,
+
+
+```python
+rollbar.init(token, environment='production', handler='blocking')
+```
+
+or use the Rollbar function wait to delay the return from your function until
+all Rollbar threads have finished. Note that we use threads for the handler if
+otherwise unspecified, therefore you must use wait if you do not set the handler.
+
+`wait` is a function which takes an optional function as an argument. It waits for
+all currently running Rollbar created threads to stop processing, meaning it waits
+for any items to be sent over the network, then it returns the result of calling
+the function passed as an argument or `None` if function was given. Hence, one can
+use it via
+
+```python
+def lambda_handler(event, context):
+    try:
+        result = ...
+        return rollbar.wait(lambda: result)
+    except:
+        rollbar.report_exc_info()
+        rollbar.wait()
+        raise
+```
+
+We provide a decorator for your handler functions which takes care of calling
+wait properly as well as catching any exceptions, namely
+`rollbar.lambda_function`:
+
+```python
+import os
+import rollbar
+
+token = os.getenv('ROLLBAR_KEY', 'missing_api_key')
+rollbar.init(token, 'production')
+
+@rollbar.lambda_function
+def lambda_handler(event, context):
+    return some_other_function('Hello from Lambda')
+```
 
 ### Other
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import copy
+import functools
 import inspect
 import json
 import logging
@@ -334,6 +335,20 @@ def init(access_token, environment='production', **kw):
 
     _initialized = True
 
+def lambda_function(f):
+    """
+    Decorator for making error handling on AWS Lambda easier
+    """
+    @functools.wraps(f)
+    def wrapper(event, context):
+        SETTINGS['handler'] = 'blocking'
+        try:
+            f(event, context)
+        except:
+            cls, exc, trace = sys.exc_info()
+            report_exc_info((cls, exc, trace.tb_next))
+            raise
+    return wrapper
 
 def report_exc_info(exc_info=None, request=None, extra_data=None, payload_data=None, level=None, **kw):
     """

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -933,7 +933,7 @@ def _add_lambda_context_data(data):
     try:
         lambda_data = {
             'lambda': {
-                'remaining_time_in_millis': context.remaining_time_in_millis(),
+                'remaining_time_in_millis': context.get_remaining_time_in_millis(),
                 'function_name': context.function_name,
                 'function_version': context.function_version,
                 'arn': context.invoked_function_arn,

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -928,7 +928,8 @@ def _add_lambda_context_data(data):
     """
     global _CURRENT_LAMBDA_CONTEXT
     context = _CURRENT_LAMBDA_CONTEXT
-    return if context is None:
+    if context is None:
+        return
     try:
         lambda_data = {
             'lambda': {


### PR DESCRIPTION
This implements a decorator `lambda_function` to be used like

```
import os
import rollbar

token = os.getenv('ROLLBAR_KEY', 'missing_api_key')
rollbar.init(token, 'production')

@rollbar.lambda_function
def lambda_handler(event, context):
    raise Exception('Hello threaded wrapped Rollbar!')
    return 'Hello from Lambda'
```

If we comment out the `raise Exception` line then everything will just run normally and the rollbar code will pass things through as necessary. If we do have an exception then Rollbar will handle sending it to the API and waiting for any processing threads as necessary. If the handler happened to be set to another value like 'blocking' then the wait is superfluous but otherwise the same outcome will be observed.