### PR TITLE
Reinit warning suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ If `locals.enabled` is `True`, extra keys are also automatically added:
 Default: `[]`
 
 </dd>
+<dt>suppress_reinit_warning
+</dt>
+<dd>If `True`, suppresses the warning normally shown when `rollbar.init()` is called multiple times. Default `False`.
+</dd>
 </dl>
 
 

--- a/README.md
+++ b/README.md
@@ -591,7 +591,6 @@ If `locals.enabled` is `True`, extra keys are also automatically added:
 Default: `[]`
 
 </dd>
-</dd>
 </dl>
 
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -244,7 +244,8 @@ SETTINGS = {
         'whitelisted_types': []
     },
     'verify_https': True,
-    'shortener_keys': []
+    'shortener_keys': [],
+    'suppress_reinit_warning': False,
 }
 
 _CURRENT_LAMBDA_CONTEXT = None
@@ -288,7 +289,8 @@ def init(access_token, environment='production', **kw):
         # NOTE: Temp solution to not being able to re-init.
         # New versions of pyrollbar will support re-initialization
         # via the (not-yet-implemented) configure() method.
-        log.warn('Rollbar already initialized. Ignoring re-init.')
+        if not SETTINGS.get('suppress_reinit_warning'):
+            log.warn('Rollbar already initialized. Ignoring re-init.')
         return
 
     SETTINGS['access_token'] = access_token


### PR DESCRIPTION
Currently if you call `rollbar.init()` twice you see a warning about the
re-init.  This is annoying in configurations where `init()` is _expected_
to be called twice.  One such configuration is a Django project where the
rollbar middleware is installed (which calls `rollbar.init()` internally),
but the project also needs to be able to run without the middleware (from
headless scripts, etc.), which requires that you call `rollbar.init()`.

The current recommendation [1] is to just live with the warning message.
I've personally taken that approach for the past year but have finally
grown weary enough of the warning message to warrant some action :).

Without this change my logs have the re-init warning scattered about:

    WARNING:rollbar:Rollbar already initialized. Ignoring re-init.
    Performing system checks...

    System check identified no issues (0 silenced).
    September 25, 2017 - 14:29:19
    Django version 1.9.10, using settings 'unicorn.settings'
    Starting development server at http://0.0.0.0:8000/
    Quit the server with CONTROL-C.
    WARNING:rollbar:Rollbar already initialized. Ignoring re-init.

With this change, no more warnings:

    Performing system checks...

    System check identified no issues (0 silenced).
    September 25, 2017 - 14:30:56
    Django version 1.9.10, using settings 'unicorn.settings'
    Starting development server at http://0.0.0.0:8000/
    Quit the server with CONTROL-C.

Related to #100 and #145

[1] https://github.com/rollbar/pyrollbar/issues/100#issuecomment-191519818
