### PR TITLE
Shortening a dict should not change it's type

### DIFF
--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -50,6 +50,13 @@ class ShortenerTransform(Transform):
 
         return self._repr.repr(obj)
 
+    def _shorten_mapping(self, obj, max_keys):
+        _len = len(obj)
+        if _len <= max_keys:
+            return obj
+
+        return {k: obj[k] for k in obj.keys()[:max_keys]}
+
     def _shorten_basic(self, obj, max_len):
         val = text(obj)
         if len(val) <= max_len:
@@ -69,6 +76,8 @@ class ShortenerTransform(Transform):
     def _shorten(self, val):
         max_size = self._get_max_size(val)
 
+        if isinstance(val, dict):
+            return self._shorten_mapping(val, max_size)
         if isinstance(val, (string_types, sequence_types)):
             return self._shorten_sequence(val, max_size)
 

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -44,14 +44,15 @@ class ShortenerTransformTest(BaseTest):
         shortener = ShortenerTransform(keys=[(key,)], **DEFAULT_LOCALS_SIZES)
         result = transforms.transform(self.data, shortener)
 
-        # the repr output can vary between Python versions
-        stripped_result_key = result[key].strip("'\"u")
-
         if key == 'dict':
-            self.assertEqual(expected, stripped_result_key.count(':'))
-        elif key == 'other':
-            self.assertIn(expected, stripped_result_key)
+            self.assertEqual(expected, len(result))
         else:
+            # the repr output can vary between Python versions
+            stripped_result_key = result[key].strip("'\"u")
+
+        if key == 'other':
+            self.assertIn(expected, stripped_result_key)
+        elif key != 'dict':
             self.assertEqual(expected, stripped_result_key)
 
         # make sure nothing else was shortened
@@ -114,3 +115,16 @@ class ShortenerTransformTest(BaseTest):
         if six.PY3:
             expected = '<rollbar.test.test_shortener_transform.TestClas...'
         self._assert_shortened('other', expected)
+
+    def test_shorten_object(self):
+        data = {'request': {'POST': {i: i for i in range(10)}}}
+        keys = shortener_keys = [
+                ('request', 'POST'),
+                ('request', 'json'),
+                ('body', 'request', 'POST'),
+                ('body', 'request', 'json'),
+                ]
+        shortener = ShortenerTransform(keys=keys, **DEFAULT_LOCALS_SIZES)
+        result = transforms.transform(data, shortener)
+        self.assertEqual(type(result), dict)
+


### PR DESCRIPTION
Fixes #197 

https://github.com/rollbar/pyrollbar/pull/176 added request.POST to the keys that we might shorten. It turns out that we shorten things basically by turning them into a string representation of themselves with an ellipses. This is problematic as it pertains to types. A string `"{'a': 1, ...}"` is not a valid JSON object even if it is reified. The problem with shortening dictionaries that they are unordered, so we have to make some arbitrary choice about what to leave in versus out. In this PR I chose to use `obj.items()[:max_items]` as the selection of the maximum number of keys. The current implementation uses whatever reprlib decides to do. In this way, I construct a new dict by pulling the key/value pairs from the old object.

Problems with this are that the result is not obviously truncated. We could add something like `{"truncated": true}` to the object or `{"...": "..."}` to make it obvious. The other alternative is to not truncate request.POST. Any other place that we might truncate a dictionary is probably fine to turn it into a string but the API will reject an item with a string value at request.POST.