### PR TITLE
Add details on `environment` option in CLI help

### DIFF
--- a/rollbar/cli.py
+++ b/rollbar/cli.py
@@ -33,7 +33,8 @@ def main():
                       metavar='ACCESS_TOKEN')
     parser.add_option('-e', '--environment',
                       dest='environment',
-                      help="The environment to report errors and messages to.",
+                      help="The environment to report errors and messages to. \
+                      Can be any string; suggestions: 'production', 'development', 'staging'",
                       metavar='ENVIRONMENT')
     parser.add_option('-u', '--url',
                       dest='endpoint_url',


### PR DESCRIPTION
To understand what I was suppose to put in `environment` option, I had to go to the [source code](https://github.com/rollbar/pyrollbar/blob/c9d34b1d1544415a17d5a79e90179a763e739bfc/rollbar/__init__.py#L282). It would be helpful to have this information directly in the CLI.