### PR TITLE
Fix `request.files_keys` for Flask

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1124,7 +1124,7 @@ def _build_werkzeug_request_data(request):
         'user_ip': _extract_user_ip(request),
         'headers': dict(request.headers),
         'method': request.method,
-        'files_keys': request.files.keys(),
+        'files_keys': list(request.files.keys()),
     }
 
     try:


### PR DESCRIPTION
Flask 1.0, Python 3

The value of `request.files_keys` when sent to Rollbar is incorrectly displayed as `<class 'dict_keyiterator'>`. Explicitly convert it to a list in `_build_werkzeug_request_data`