### PR TITLE
requests.Session is not thread-safe, use thread local storage

### DIFF
--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -1,14 +1,23 @@
 import requests
+import threading
 
-_session = requests.Session()
+
+_local = threading.local()
+
+
+def _session():
+    if hasattr(_local, 'session'):
+        return _local.session
+    _local.session = requests.Session()
+    return _local.session
 
 
 def post(*args, **kw):
-    return _session.post(*args, **kw)
+    return _session().post(*args, **kw)
 
 
 def get(*args, **kw):
-    return _session.get(*args, **kw)
+    return _session().get(*args, **kw)
 
 
 __all__ = ['post', 'get']


### PR DESCRIPTION
Fixes #215 

The Session object in the requests library is not thread-safe. The library as a whole claims to be thread-safe, it is not. This PR uses thread-local storage to cache a session otherwise it creates one.