### PR TITLE
make werkzeug request handling more general

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -61,7 +61,7 @@ else:
     del ImproperlyConfigured
 
 try:
-    from werkzeug.wrappers import Request as WerkzeugRequest
+    from werkzeug.wrappers import BaseRequest as WerkzeugRequest
 except (ImportError, SyntaxError):
     WerkzeugRequest = None
 
@@ -1030,6 +1030,7 @@ def _get_actual_request(request):
             return None
         return actual_request
     return request
+
 
 def _build_request_data(request):
     """


### PR DESCRIPTION
werkzeug.wrappers.Request is a subclass of .BaseRequest and we only need the methods defined on BaseRequest so we can use an isinstance check for the parent of the hierarchy. This allows people to subclass BaseRequest directly (which is recommended by werkzeug) and still get request data gathering working.