### PR TITLE
Support Django Channels' AsgiRequest

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1125,10 +1125,10 @@ def _build_django_request_data(request):
         'method': request.method,
         'GET': dict(request.GET),
         'POST': dict(request.POST),
-        'user_ip': _wsgi_extract_user_ip(request.environ),
+        'user_ip': _wsgi_extract_user_ip(request.META),
     }
 
-    request_data['headers'] = _extract_wsgi_headers(request.environ.items())
+    request_data['headers'] = _extract_wsgi_headers(request.META.items())
 
     return request_data
 

--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -86,6 +86,7 @@ import rollbar
 from django.core.exceptions import MiddlewareNotUsed
 from django.conf import settings
 from django.http import Http404
+from six import reraise
 
 try:
     from django.urls import resolve
@@ -292,7 +293,7 @@ class RollbarNotifierMiddlewareOnly404(MiddlewareMixin):
         try:
             if hasattr(request, '_rollbar_notifier_original_http404_exc_info'):
                 exc_type, exc_value, exc_traceback = request._rollbar_notifier_original_http404_exc_info
-                raise exc_type, exc_value, exc_traceback
+                reraise(exc_type, exc_value, exc_traceback)
             else:
                 raise Http404()
         except Exception as exc:


### PR DESCRIPTION
AsgiRequest does not have an `environ` member like the WSGIRequest.  Instead, use the `META` dictionary, which contains the HTTP headers for both types of requests.