### PR TITLE
Addresses errors when request has no META attribute

### DIFF
--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -141,7 +141,7 @@ class RollbarNotifierMiddleware(MiddlewareMixin):
 
             data['framework'] = 'django'
 
-            if request:
+            if request and hasattr(request, 'META'):
                 request.META['rollbar.uuid'] = data['uuid']
 
         rollbar.BASE_DATA_HOOK = hook


### PR DESCRIPTION
This corrects a bug that can cause errors when the request has no META attribute