### PR TITLE
Http proxy support

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -259,6 +259,7 @@ SETTINGS = {
     'capture_username': False,
     'capture_ip': True,
     'log_all_rate_limited_items': True,
+    'http_proxy': None,  # HTTP proxy '<host>:<port>'
 }
 
 _CURRENT_LAMBDA_CONTEXT = None
@@ -1370,10 +1371,11 @@ def _post_api(path, payload_str, access_token=None):
 
     url = urljoin(SETTINGS['endpoint'], path)
     resp = transport.post(url,
-                         data=payload_str,
-                         headers=headers,
-                         timeout=SETTINGS.get('timeout', DEFAULT_TIMEOUT),
-                         verify=SETTINGS.get('verify_https', True))
+                          data=payload_str,
+                          headers=headers,
+                          timeout=SETTINGS.get('timeout', DEFAULT_TIMEOUT),
+                          verify=SETTINGS.get('verify_https', True),
+                          proxy=SETTINGS.get('http_proxy'))
 
     return _parse_response(path, SETTINGS['access_token'], payload_str, resp)
 
@@ -1382,7 +1384,10 @@ def _get_api(path, access_token=None, endpoint=None, **params):
     access_token = access_token or SETTINGS['access_token']
     url = urljoin(endpoint or SETTINGS['endpoint'], path)
     params['access_token'] = access_token
-    resp = transport.get(url, params=params, verify=SETTINGS.get('verify_https', True))
+    resp = transport.get(url,
+                         params=params,
+                         verify=SETTINGS.get('verify_https', True),
+                         proxy=SETTINGS.get('http_proxy'))
     return _parse_response(path, access_token, params, resp, endpoint=endpoint)
 
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -259,8 +259,7 @@ SETTINGS = {
     'capture_username': False,
     'capture_ip': True,
     'log_all_rate_limited_items': True,
-    'http_proxy_host': None,
-    'http_proxy_port': None,
+    'http_proxy': None,
     'http_proxy_user': None,
     'http_proxy_password': None,
 }
@@ -1378,8 +1377,7 @@ def _post_api(path, payload_str, access_token=None):
                           headers=headers,
                           timeout=SETTINGS.get('timeout', DEFAULT_TIMEOUT),
                           verify=SETTINGS.get('verify_https', True),
-                          proxy_host=SETTINGS.get('http_proxy_host'),
-                          proxy_port=SETTINGS.get('http_proxy_port'),
+                          proxy=SETTINGS.get('http_proxy'),
                           proxy_user=SETTINGS.get('http_proxy_user'),
                           proxy_password=SETTINGS.get('http_proxy_password'))
 
@@ -1393,8 +1391,7 @@ def _get_api(path, access_token=None, endpoint=None, **params):
     resp = transport.get(url,
                          params=params,
                          verify=SETTINGS.get('verify_https', True),
-                         proxy_host=SETTINGS.get('http_proxy_host'),
-                         proxy_port=SETTINGS.get('http_proxy_port'),
+                         proxy=SETTINGS.get('http_proxy'),
                          proxy_user=SETTINGS.get('http_proxy_user'),
                          proxy_password=SETTINGS.get('http_proxy_password'))
     return _parse_response(path, access_token, params, resp, endpoint=endpoint)

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -259,7 +259,10 @@ SETTINGS = {
     'capture_username': False,
     'capture_ip': True,
     'log_all_rate_limited_items': True,
-    'http_proxy': None,  # HTTP proxy '<host>:<port>'
+    'http_proxy_host': None,
+    'http_proxy_port': None,
+    'http_proxy_user': None,
+    'http_proxy_password': None,
 }
 
 _CURRENT_LAMBDA_CONTEXT = None
@@ -1375,7 +1378,10 @@ def _post_api(path, payload_str, access_token=None):
                           headers=headers,
                           timeout=SETTINGS.get('timeout', DEFAULT_TIMEOUT),
                           verify=SETTINGS.get('verify_https', True),
-                          proxy=SETTINGS.get('http_proxy'))
+                          proxy_host=SETTINGS.get('http_proxy_host'),
+                          proxy_port=SETTINGS.get('http_proxy_port'),
+                          proxy_user=SETTINGS.get('http_proxy_user'),
+                          proxy_password=SETTINGS.get('http_proxy_password'))
 
     return _parse_response(path, SETTINGS['access_token'], payload_str, resp)
 
@@ -1387,7 +1393,10 @@ def _get_api(path, access_token=None, endpoint=None, **params):
     resp = transport.get(url,
                          params=params,
                          verify=SETTINGS.get('verify_https', True),
-                         proxy=SETTINGS.get('http_proxy'))
+                         proxy_host=SETTINGS.get('http_proxy_host'),
+                         proxy_port=SETTINGS.get('http_proxy_port'),
+                         proxy_user=SETTINGS.get('http_proxy_user'),
+                         proxy_password=SETTINGS.get('http_proxy_password'))
     return _parse_response(path, access_token, params, resp, endpoint=endpoint)
 
 

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -12,20 +12,24 @@ def _session():
     return _local.session
 
 
-def _get_proxy_cfg(proxy):
-    if proxy:
+def _get_proxy_cfg(proxy_host=None, proxy_port=8080, proxy_user=None, proxy_password=None):
+    if proxy_host and proxy_user and proxy_password:
         return {
-            'http': proxy,
+            'http': 'http://{}:{}@{}:{}'.format(proxy_user, proxy_password, proxy_host, proxy_port),
+        }
+    elif proxy_host:
+        return {
+            'http': 'http://{}:{}'.format(proxy_host, proxy_port),
         }
 
 
-def post(*args, proxy=None, **kw):
+def post(*args, proxy_host=None, proxy_port=None, proxy_user=None, proxy_password=None, **kw):
 
-    return _session().post(*args, proxies=_get_proxy_cfg(proxy), **kw)
+    return _session().post(*args, proxies=_get_proxy_cfg(proxy_host, proxy_port, proxy_user, proxy_password), **kw)
 
 
-def get(*args, proxy=None, **kw):
-    return _session().get(*args, proxies=_get_proxy_cfg(proxy), **kw)
+def get(*args, proxy_host=None, proxy_port=None, proxy_user=None, proxy_password=None, **kw):
+    return _session().get(*args, proxies=_get_proxy_cfg(proxy_host, proxy_port, proxy_user, proxy_password), **kw)
 
 
 __all__ = ['post', 'get']

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -12,24 +12,24 @@ def _session():
     return _local.session
 
 
-def _get_proxy_cfg(proxy_host=None, proxy_port=8080, proxy_user=None, proxy_password=None):
-    if proxy_host and proxy_user and proxy_password:
+def _get_proxy_cfg(proxy=None, proxy_user=None, proxy_password=None):
+    if proxy and proxy_user and proxy_password:
         return {
-            'http': 'http://{}:{}@{}:{}'.format(proxy_user, proxy_password, proxy_host, proxy_port),
+            'http': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
         }
-    elif proxy_host:
+    elif proxy:
         return {
-            'http': 'http://{}:{}'.format(proxy_host, proxy_port),
+            'http': 'http://{}'.format(proxy),
         }
 
 
-def post(*args, proxy_host=None, proxy_port=None, proxy_user=None, proxy_password=None, **kw):
+def post(*args, proxy=None, proxy_user=None, proxy_password=None, **kw):
 
-    return _session().post(*args, proxies=_get_proxy_cfg(proxy_host, proxy_port, proxy_user, proxy_password), **kw)
+    return _session().post(*args, proxies=_get_proxy_cfg(proxy, proxy_user, proxy_password), **kw)
 
 
-def get(*args, proxy_host=None, proxy_port=None, proxy_user=None, proxy_password=None, **kw):
-    return _session().get(*args, proxies=_get_proxy_cfg(proxy_host, proxy_port, proxy_user, proxy_password), **kw)
+def get(*args, proxy=None, proxy_user=None, proxy_password=None, **kw):
+    return _session().get(*args, proxies=_get_proxy_cfg(proxy, proxy_user, proxy_password), **kw)
 
 
 __all__ = ['post', 'get']

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -12,12 +12,20 @@ def _session():
     return _local.session
 
 
-def post(*args, **kw):
-    return _session().post(*args, **kw)
+def _get_proxy_cfg(proxy):
+    if proxy:
+        return {
+            'http': proxy,
+        }
 
 
-def get(*args, **kw):
-    return _session().get(*args, **kw)
+def post(*args, proxy=None, **kw):
+
+    return _session().post(*args, proxies=_get_proxy_cfg(proxy), **kw)
+
+
+def get(*args, proxy=None, **kw):
+    return _session().get(*args, proxies=_get_proxy_cfg(proxy), **kw)
 
 
 __all__ = ['post', 'get']

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -12,7 +12,10 @@ def _session():
     return _local.session
 
 
-def _get_proxy_cfg(proxy=None, proxy_user=None, proxy_password=None):
+def _get_proxy_cfg(kw):
+    proxy = kw.pop('proxy', None)
+    proxy_user = kw.pop('proxy_user', None)
+    proxy_password = kw.pop('proxy_password', None)
     if proxy and proxy_user and proxy_password:
         return {
             'http': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
@@ -25,12 +28,14 @@ def _get_proxy_cfg(proxy=None, proxy_user=None, proxy_password=None):
         }
 
 
-def post(*args, proxy=None, proxy_user=None, proxy_password=None, **kw):
-    return _session().post(*args, proxies=_get_proxy_cfg(proxy, proxy_user, proxy_password), **kw)
+def post(*args, **kw):
+    proxies = _get_proxy_cfg(kw)
+    return _session().post(*args, proxies=proxies, **kw)
 
 
-def get(*args, proxy=None, proxy_user=None, proxy_password=None, **kw):
-    return _session().get(*args, proxies=_get_proxy_cfg(proxy, proxy_user, proxy_password), **kw)
+def get(*args, **kw):
+    proxies = _get_proxy_cfg(kw)
+    return _session().get(*args, proxies=proxies, **kw)
 
 
 __all__ = ['post', 'get']

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -16,15 +16,16 @@ def _get_proxy_cfg(proxy=None, proxy_user=None, proxy_password=None):
     if proxy and proxy_user and proxy_password:
         return {
             'http': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
+            'https': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
         }
     elif proxy:
         return {
             'http': 'http://{}'.format(proxy),
+            'https': 'http://{}'.format(proxy),
         }
 
 
 def post(*args, proxy=None, proxy_user=None, proxy_password=None, **kw):
-
     return _session().post(*args, proxies=_get_proxy_cfg(proxy, proxy_user, proxy_password), **kw)
 
 


### PR DESCRIPTION
This is a proposal for https://github.com/rollbar/pyrollbar/issues/246
Users can set `http_proxy` (host:port), `http_proxy_username` and `http_proxy_password`.
If user and password is given, basic auth is used to open the proxy.
If `http_proxy` is not set, no proxy will be used.