### PR TITLE
Fixes issue #277

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -56,7 +56,13 @@ class RollbarHandler(logging.Handler):
         log records we notify Rollbar about instead of which
         records we save to the history.
         """
-        self.notify_level = level
+        # hack to fix backward compatibility in Python3
+        try:
+            from logging import _checkLevel
+        except ImportError:
+            _checkLevel = lambda lvl: lvl
+
+        self.notify_level = _checkLevel(level)
 
     def setHistoryLevel(self, level):
         """

--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -23,6 +23,12 @@ import threading
 
 import rollbar
 
+# hack to fix backward compatibility in Python3
+try:
+    from logging import _checkLevel
+except ImportError:
+    _checkLevel = lambda lvl: lvl
+
 
 class RollbarHandler(logging.Handler):
     SUPPORTED_LEVELS = set(('debug', 'info', 'warning', 'error', 'critical'))
@@ -42,7 +48,7 @@ class RollbarHandler(logging.Handler):
         if access_token is not None:
             rollbar.init(access_token, environment, **kw)
 
-        self.notify_level = level
+        self.notify_level = _checkLevel(level)
 
         self.history_size = history_size
         if history_size > 0:
@@ -56,12 +62,6 @@ class RollbarHandler(logging.Handler):
         log records we notify Rollbar about instead of which
         records we save to the history.
         """
-        # hack to fix backward compatibility in Python3
-        try:
-            from logging import _checkLevel
-        except ImportError:
-            _checkLevel = lambda lvl: lvl
-
         self.notify_level = _checkLevel(level)
 
     def setHistoryLevel(self, level):


### PR DESCRIPTION
Python3 changed the implementation to be backwards incompatible. This PR fixes a bug by using an internal method in Python3 logging to set the `notify_level`.