### PR TITLE
Add missing param to handle_error() in Pyramid middleware

### DIFF
--- a/rollbar/contrib/pyramid/__init__.py
+++ b/rollbar/contrib/pyramid/__init__.py
@@ -178,5 +178,5 @@ class RollbarMiddleware(object):
             return self.app(environ, start_resp)
         except Exception:
             from pyramid.request import Request
-            handle_error(self.settings, Request(environ))
+            handle_error(self.settings, Request(environ), sys.exc_info())
             raise


### PR DESCRIPTION
Looks like the extra param was added in b8a6a650 but the call in `RollbarMiddleware` was not updated accordingly.