### PR TITLE
Catch locals serialization errors

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -837,7 +837,10 @@ def _add_locals_data(data, exc_info):
         if keywordspec:
             cur_frame['keywordspec'] = keywordspec
         if _locals:
-            cur_frame['locals'] = dict((k, _serialize_frame_data(v)) for k, v in iteritems(_locals))
+            try:
+                cur_frame['locals'] = dict((k, _serialize_frame_data(v)) for k, v in iteritems(_locals))
+            except Exception:
+                log.exception('Error while serializing frame data.')
 
         frame_num += 1
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -302,6 +302,22 @@ class RollbarTest(BaseTest):
         self.assertEqual(33, payload['data']['body']['trace']['frames'][-1]['locals']['arg1'])
 
     @mock.patch('rollbar.send_payload')
+    def test_failed_locals_serialization(self, send_payload):
+
+        class tmp(object):
+            @property
+            def __class__(self):
+                foo()
+
+        try:
+            t = tmp()
+            raise Exception('trigger_serialize')
+        except:
+            rollbar.report_exc_info()
+
+        self.assertEqual(send_payload.called, True)
+
+    @mock.patch('rollbar.send_payload')
     def test_args_lambda_no_args(self, send_payload):
 
         _raise = lambda: foo()


### PR DESCRIPTION
This is a bit of an edge case but caused us to miss a few rollbars. 