### PR TITLE
Fix params to handle_error() in Pyramid middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,10 +93,14 @@ matrix:
     - python: "3.6"
       env: DJANGO_VERSION=1.11.1
 
+    - python: "3.6"
+      env: PYRAMID_VERSION=1.9.2
+
 install:
   - if [ -v FLASK_VERSION ]; then pip install Flask==$FLASK_VERSION; fi
   - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq; fi
   - if [ -v DJANGO_VERSION ]; then pip install Django==$DJANGO_VERSION; fi
+  - if [ -v PYRAMID_VERSION ]; then pip install pyramid==$PYRAMID_VERSION; fi
 
 script:
   - python setup.py test

--- a/rollbar/contrib/pyramid/__init__.py
+++ b/rollbar/contrib/pyramid/__init__.py
@@ -176,7 +176,7 @@ class RollbarMiddleware(object):
     def __call__(self, environ, start_resp):
         try:
             return self.app(environ, start_resp)
-        except Exception:
+        except Exception as exc:
             from pyramid.request import Request
-            handle_error(self.settings, Request(environ), sys.exc_info())
+            handle_error(Request(environ), exc, sys.exc_info())
             raise

--- a/rollbar/test/test_pyramid.py
+++ b/rollbar/test/test_pyramid.py
@@ -1,0 +1,39 @@
+import mock
+
+from rollbar.test import BaseTest
+
+try:
+    from pyramid.request import Request
+
+    PYRAMID_INSTALLED = True
+except ImportError:
+    PYRAMID_INSTALLED = False
+
+
+if PYRAMID_INSTALLED:
+
+    class PyramidMiddlewareTest(BaseTest):
+        def test_catch_exception_in_the_wsgi_app(self):
+            from rollbar.contrib.pyramid import RollbarMiddleware
+
+            def wsgi_app(environ, start_resp):
+                raise RuntimeError("oops")
+
+            middleware = RollbarMiddleware({}, wsgi_app)
+
+            with mock.patch("rollbar.report_exc_info") as mock_report:
+                with self.assertRaises(RuntimeError):
+                    middleware(environ={}, start_resp=lambda: None)
+
+            self.assertEqual(mock_report.call_count, 1)
+
+            args, kwargs = mock_report.call_args
+            self.assertEqual(kwargs, {})
+
+            exc_info, request = args
+
+            exc_type, exc_value, exc_tb = exc_info
+            self.assertEqual(exc_type, RuntimeError)
+            self.assertIsInstance(exc_value, RuntimeError)
+
+            self.assertIsInstance(request, Request)


### PR DESCRIPTION
In the original fix in #283 I had missed that the addition of `exc_info` was not the only change in the signature of the `handle_error` function:

- before: `handle_error(settings, request)`
- after: `handle_error(request, exception, exc_info)`

Thanks to @indepndnt for noticing the problem!