### PR TITLE
Handle disallowed host when getting uri

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1100,8 +1100,12 @@ def _extract_wsgi_headers(items):
 
 
 def _build_django_request_data(request):
+    try:
+        uri = request.build_absolute_uri()
+    except DisallowedHost:
+        uri = request.get_raw_uri()
     request_data = {
-        'url': request.build_absolute_uri(),
+        'url': uri,
         'method': request.method,
         'GET': dict(request.GET),
         'POST': dict(request.POST),

--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -141,7 +141,7 @@ class RollbarNotifierMiddleware(MiddlewareMixin):
 
             data['framework'] = 'django'
 
-            if request:
+            if request and hasattr(request, 'META'):
                 request.META['rollbar.uuid'] = data['uuid']
 
         rollbar.BASE_DATA_HOOK = hook


### PR DESCRIPTION
When request.build_absolute_uri() throws DisallowedHost then the message does not make it to Rollbar. This change catches the DisallowedHost exception and then calls request.get_raw_uri() to ensure that the message continues to process and become sent to Rollbar