### PR TITLE
See PR #288

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1127,12 +1127,8 @@ def _extract_wsgi_headers(items):
 
 
 def _build_django_request_data(request):
-    try:
-        uri = request.build_absolute_uri()
-    except DisallowedHost:
-        uri = request.get_raw_uri()
     request_data = {
-        'url': uri,
+        'url': request.get_raw_uri(),
         'method': request.method,
         'GET': dict(request.GET),
         'POST': dict(request.POST),


### PR DESCRIPTION
My comment from that PR ->

"Actually that is a good point, build_absolute_uri with a None location,
basically boils down to the same thing as get_raw_uri plus a little bit
of logic to maybe throw the DisallowedHost exception. If we are just
going to truck right through that then we should skip the ceremony and
use get_raw_uri from the get-go. The only difference is that get_raw_uri
returns a string and build_absolute_uri calls iri_to_uri on the string
before returning. That extra call I don't think actually matters for our
use case as we should theoretically accept full UTF-8 URLs even if that
isn't what browsers work with."