### PR TITLE
Allow floats as circular references

### DIFF
--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -9,10 +9,10 @@ if isinstance(string_types, tuple):
 else:
     _ALLOWED_CIRCULAR_REFERENCE_TYPES.append(string_types)
 
-if isinstance(integer_types, tuple):
-    _ALLOWED_CIRCULAR_REFERENCE_TYPES.extend(integer_types)
+if isinstance(number_types, tuple):
+    _ALLOWED_CIRCULAR_REFERENCE_TYPES.extend(number_types)
 else:
-    _ALLOWED_CIRCULAR_REFERENCE_TYPES.append(integer_types)
+    _ALLOWED_CIRCULAR_REFERENCE_TYPES.append(number_types)
 
 _ALLOWED_CIRCULAR_REFERENCE_TYPES = tuple(_ALLOWED_CIRCULAR_REFERENCE_TYPES)
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -931,7 +931,7 @@ class RollbarTest(BaseTest):
             raise Exception()
 
         try:
-            obj = {}
+            obj = {'x': 42.3}
             obj['child'] = {
                 'parent': obj
             }
@@ -949,6 +949,17 @@ class RollbarTest(BaseTest):
         self.assertTrue(
             (isinstance(payload['data']['body']['trace']['frames'][-1]['locals']['obj'], dict) and
              'child' in payload['data']['body']['trace']['frames'][-1]['locals']['obj'])
+
+             or
+
+            (isinstance(payload['data']['body']['trace']['frames'][-1]['locals']['obj'], string_types) and
+             payload['data']['body']['trace']['frames'][-1]['locals']['obj'].startswith('<CircularReference'))
+        )
+
+        self.assertTrue(
+            (isinstance(payload['data']['body']['trace']['frames'][-1]['locals']['obj'], dict) and
+             'x' in payload['data']['body']['trace']['frames'][-1]['locals']['obj'] and
+             payload['data']['body']['trace']['frames'][-1]['locals']['obj']['x'] == 42.3)
 
              or
 


### PR DESCRIPTION
Fixes #286

Number types are okay if we see them multiple times, currently we only
treat integers this way but floats should also be allowed.