### PR TITLE
Fix Python 3.7 deprecation warnings for collections.abc imports

### DIFF
--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -5,6 +5,13 @@ import os
 import sys
 from array import array
 
+try:
+    # Python 3
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.7
+    from collections import Mapping
+
 import six
 from six.moves import urllib
 
@@ -15,7 +22,7 @@ binary_type = six.binary_type
 integer_types = six.integer_types
 number_types = integer_types + (float, )
 string_types = six.string_types
-sequence_types = (collections.Mapping, list, tuple, set, frozenset, array, collections.deque)
+sequence_types = (Mapping, list, tuple, set, frozenset, array, collections.deque)
 
 urlparse = urllib.parse.urlparse
 urlsplit = urllib.parse.urlsplit

--- a/rollbar/lib/traverse.py
+++ b/rollbar/lib/traverse.py
@@ -1,5 +1,13 @@
-import collections
 import logging
+
+try:
+    # Python 3
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2.7
+    from collections import Mapping
+    from collections import Sequence
 
 from rollbar.lib import binary_type, iteritems, string_types, circular_reference_label
 
@@ -59,7 +67,7 @@ def get_type(obj):
     if isinstance(obj, (string_types, binary_type)):
         return STRING
 
-    if isinstance(obj, collections.Mapping):
+    if isinstance(obj, Mapping):
         return MAPPING
 
     if isinstance(obj, tuple):
@@ -71,7 +79,7 @@ def get_type(obj):
     if isinstance(obj, set):
         return SET
 
-    if isinstance(obj, collections.Sequence):
+    if isinstance(obj, Sequence):
         return LIST
 
     return DEFAULT


### PR DESCRIPTION
Running `pyrollbar` in Python 3.7 applications generates a couple of deprecation warnings that should probably be taken care of:
* `/dev/pyrollbar/rollbar/lib/traverse.py:74: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`
* `/dev/pyrollbar/rollbar/lib/__init__.py:18: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`

So I made ya a little fix - tests pass in both 3.7.0 and 3.7.1 environments