### PR TITLE
Handle SimpleLazyObject in payloads

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -22,7 +22,7 @@ import wsgiref.util
 import requests
 import six
 
-from rollbar.lib import events, filters, dict_merge, parse_qs, text, transport, urljoin, iteritems, RollbarJSONEncoder
+from rollbar.lib import events, filters, dict_merge, parse_qs, text, transport, urljoin, iteritems, defaultJSONEncode
 
 
 __version__ = '0.14.5'
@@ -1329,7 +1329,7 @@ def _build_payload(data):
 
 
 def _serialize_payload(payload):
-    return json.dumps(payload, cls=RollbarJSONEncoder)
+    return json.dumps(payload, default=defaultJSONEncode)
 
 
 def _send_payload(payload_str, access_token):

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -22,7 +22,8 @@ import wsgiref.util
 import requests
 import six
 
-from rollbar.lib import events, filters, dict_merge, parse_qs, text, transport, urljoin, iteritems
+from rollbar.lib import events, filters, dict_merge, parse_qs, text, transport, urljoin, iteritems, RollbarJSONEncoder
+
 
 __version__ = '0.14.5'
 __log_name__ = 'rollbar'
@@ -1328,7 +1329,7 @@ def _build_payload(data):
 
 
 def _serialize_payload(payload):
-    return json.dumps(payload)
+    return json.dumps(payload, cls=RollbarJSONEncoder)
 
 
 def _send_payload(payload_str, access_token):

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -4,6 +4,7 @@ import copy
 import os
 import sys
 from array import array
+import json
 
 try:
     # Python 3
@@ -212,3 +213,16 @@ def unencodable_object_label(data):
 def undecodable_object_label(data):
     return '<Undecodable type:(%s) base64:(%s)>' % (type(data).__name__,
                                                     base64.b64encode(data).decode('ascii'))
+
+try:
+    from django.utils.functional import SimpleLazyObject
+except ImportError:
+    SimpleLazyObject = None
+
+class RollbarJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if SimpleLazyObject and isinstance(obj, SimpleLazyObject):
+            if not obj._wrapped:
+                obj._setup()
+            return obj._wrapped
+        return json.JSONEncoder.default(self, obj)

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -219,10 +219,10 @@ try:
 except ImportError:
     SimpleLazyObject = None
 
-class RollbarJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if SimpleLazyObject and isinstance(obj, SimpleLazyObject):
-            if not obj._wrapped:
-                obj._setup()
-            return obj._wrapped
-        return json.JSONEncoder.default(self, obj)
+
+def defaultJSONEncode(o):
+    if SimpleLazyObject and isinstance(o, SimpleLazyObject):
+        if not o._wrapped:
+            o._setup()
+        return o._wrapped
+    raise TypeError(repr(o) + " is not JSON serializable")

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -225,4 +225,4 @@ def defaultJSONEncode(o):
         if not o._wrapped:
             o._setup()
         return o._wrapped
-    raise TypeError(repr(o) + " is not JSON serializable")
+    return repr(o) + " is not JSON serializable"


### PR DESCRIPTION
This needs some cleanup, but the basic idea is to handle SimpleLazyObject via a custom JSONEncoder subclass

Fixes #295 