### PR TITLE
Add the authorization header to the default scrub fields list.

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -238,6 +238,7 @@ SETTINGS = {
         'accessToken',
         'auth',
         'authentication',
+        'authorization',
     ],
     'url_fields': ['url', 'link', 'href'],
     'notifier': {


### PR DESCRIPTION
Hi Rollbar,

I was surprised to find that the `Authorization` header is not being scrubbed by default in the python library. I saw #142, and while I understand that this can easily be added to the instance config, I think it's also a good idea to be secure by default and have this included by default.

Thanks.