### PR TITLE
Add quart to contrib

### DIFF
--- a/rollbar/contrib/quart/__init__.py
+++ b/rollbar/contrib/quart/__init__.py
@@ -1,0 +1,19 @@
+"""
+Integration with Quart
+"""
+
+from quart import request
+import rollbar
+
+
+def report_exception(app, exception):
+    rollbar.report_exc_info(request=request)
+
+
+def _hook(request, data):
+    data['framework'] = 'quart'
+
+    if request:
+        data['context'] = str(request.url_rule)
+
+rollbar.BASE_DATA_HOOK = _hook


### PR DESCRIPTION
This adds support for the Quart web framework to the Rollbar Python client.

Quart is an async web library that is feature-compatible with Flask and is usually a drop-in replacement. This makes converting Flask apps to Quart very easy. This also applies to making third-party extensions easy to integrate provided they already support Flask.

This pull request adds `rollbar.contrib.quart` which copies `rollbar.contrib.flask` with minor changes.

I've also created a gist showing an example Quart app based on the Flask example linked to in the Rollbar docs:
https://gist.github.com/flyinactor91/a6afb0a62d9ea69aa9ebecc2ff63bdbf

A note in the example app: line 35 adds `weak=False` to the `connect` call. If the default `True` is kept, the `blinker` Signal class will delete the Rollbar handler prematurely and signals won't reach Rollbar's servers.