### PR TITLE
added support for django 1.7 & 1.8 in _build_django_request_data

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1129,8 +1129,13 @@ def _extract_wsgi_headers(items):
 
 
 def _build_django_request_data(request):
+    try:
+        url = request.get_raw_uri()
+    except AttributeError:
+        url = request.build_absolute_uri()
+
     request_data = {
-        'url': request.get_raw_uri(),
+        'url': url,
         'method': request.method,
         'GET': dict(request.GET),
         'POST': dict(request.POST),


### PR DESCRIPTION
this fixes: 
```
ERROR:rollbar:Exception while building request_data for Rollbar payload: AttributeError("'WSGIRequest' object has no attribute 'get_raw_uri'",)
```
on django 1.7 & django 1.8