### PR TITLE
Send Rollbar access token in HTTP header

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -687,7 +687,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
         data = dict_merge(data, payload_data)
 
     payload = _build_payload(data)
-    send_payload(payload, data.get('access_token'))
+    send_payload(payload, payload.get('access_token'))
 
     return data['uuid']
 
@@ -762,7 +762,7 @@ def _report_message(message, level, request, extra_data, payload_data):
         data = dict_merge(data, payload_data)
 
     payload = _build_payload(data)
-    send_payload(payload, data.get('access_token'))
+    send_payload(payload, payload.get('access_token'))
 
     return data['uuid']
 


### PR DESCRIPTION
It seems we are not sending the access token in the
`X-Rollbar-Access-Token` header. When passing the token to
`send_payload()` we are taking the token from the `data` part of the
payload instead `payload`