### PR TITLE
Apply logger formatting to Rollbar messages

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -139,7 +139,7 @@ class RollbarHandler(logging.Handler):
                                                extra_data=extra_data,
                                                payload_data=payload_data)
             else:
-                uuid = rollbar.report_message(record.msg,
+                uuid = rollbar.report_message(self.format(record),
                                               level=level,
                                               request=request,
                                               extra_data=extra_data,

--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -139,7 +139,7 @@ class RollbarHandler(logging.Handler):
                                                extra_data=extra_data,
                                                payload_data=payload_data)
             else:
-                uuid = rollbar.report_message(self.format(record),
+                uuid = rollbar.report_message(record.getMessage(),
                                               level=level,
                                               request=request,
                                               extra_data=extra_data,

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -42,13 +42,13 @@ class LogHandlerTest(BaseTest):
         return logger
 
     @mock.patch('rollbar.send_payload')
-    def test_message_stays_unformatted(self, send_payload):
+    def test_message_gets_formatted(self, send_payload):
         logger = self._create_logger()
         logger.warning("Hello %d %s", 1, 'world')
 
         payload = send_payload.call_args[0][0]
 
-        self.assertEqual(payload['data']['body']['message']['body'], "Hello %d %s")
+        self.assertEqual(payload['data']['body']['message']['body'], "Hello 1 world")
         self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
         self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
 


### PR DESCRIPTION
fix #311 

Invoke logger formatters on the `LogRecord` to construct the Rollbar message.

*Reason*
In Django `HttpResponseBadRequest` and other 400+ status code responses are logged using `log_response("%s: %s", args)`. There are other calls to `log_response` in Django code of the same nature.

This results in items in Rollbar account like:
`#667 %s: %s (/lib/python*/site-packages/django/utils/log.py:log_response)`
`#666 "%s" %s %s (/lib/python*/site-packages/django/core/servers/basehttp.py:log_message)`

After applying the fromatter the messages become much more meaningful:
`#676 Bad Request: /rollbar/ (/lib/python*/site-packages/django/utils/log.py:log_response)`
`#675 "GET /rollbar/ HTTP/1.1" 400 22 (/lib/python*/site-packages/django/core/servers/basehttp.py:log_message)`

@rokob is there a reason why messages were sent unformatted before? There was even a test for it. I'm not sure if I'm missing something here