### PR TITLE
calls getMessage instead of just blindly passing the msg string…

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -139,7 +139,7 @@ class RollbarHandler(logging.Handler):
                                                extra_data=extra_data,
                                                payload_data=payload_data)
             else:
-                uuid = rollbar.report_message(record.msg,
+                uuid = rollbar.report_message(record.getMessage(),
                                               level=level,
                                               request=request,
                                               extra_data=extra_data,


### PR DESCRIPTION
… which, according to the spec https://docs.python.org/3/library/logging.html#logrecord-objects, is possibly a format string with placeholders for variable data ... to merge into the msg argument to obtain the event description. Indeed getMessage is called above in the poulation of the message_template while processing records having exec_info, and that it is not called here is probably an oversight.