### PR TITLE
Handle recursive re-raising of exceptions

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -696,11 +696,16 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
 def _walk_trace_chain(cls, exc, trace):
     trace_chain = [_trace_data(cls, exc, trace)]
 
+    seen_exceptions = {exc}
+
     while True:
         exc = getattr(exc, '__cause__', None) or getattr(exc, '__context__', None)
         if not exc:
             break
         trace_chain.append(_trace_data(type(exc), exc, getattr(exc, '__traceback__', None)))
+        if exc in seen_exceptions:
+            break
+        seen_exceptions.add(exc)
 
     return trace_chain
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -281,6 +281,52 @@ class RollbarTest(BaseTest):
         self.assertEqual(payload['data']['body']['trace_chain'][1]['frames'][-1]['locals']['bar_local'], 'bar')
 
     @mock.patch('rollbar.send_payload')
+    def test_report_exception_with_same_exception_as_cause(self, send_payload):
+        def _raise_cause():
+            bar_local = 'bar'
+            raise CauseException('bar')
+
+        def _raise_ex():
+            try:
+                _raise_cause()
+            except CauseException as cause:
+                # python2 won't automatically assign this traceback...
+                exc_info = sys.exc_info()
+                setattr(cause, '__traceback__', exc_info[2])
+
+                try:
+                    foo_local = 'foo'
+                    # in python3 this would normally be expressed as
+                    # raise cause from cause
+                    setattr(cause, '__cause__', cause)  # PEP-3134
+                    raise cause
+                except:
+                    rollbar.report_exc_info()
+
+        _raise_ex()
+
+        self.assertEqual(send_payload.called, True)
+
+        payload = send_payload.call_args[0][0]
+
+        self.assertEqual(payload['access_token'], _test_access_token)
+        self.assertIn('body', payload['data'])
+        self.assertNotIn('trace', payload['data']['body'])
+        self.assertIn('trace_chain', payload['data']['body'])
+        self.assertEqual(2, len(payload['data']['body']['trace_chain']))
+
+        self.assertIn('exception', payload['data']['body']['trace_chain'][0])
+        self.assertEqual(payload['data']['body']['trace_chain'][0]['exception']['message'], 'bar')
+        self.assertEqual(payload['data']['body']['trace_chain'][0]['exception']['class'], 'CauseException')
+        frames = payload['data']['body']['trace_chain'][0]['frames']
+        self.assertEqual(payload['data']['body']['trace_chain'][0]['frames'][0]['locals']['foo_local'], 'foo')
+
+        self.assertIn('exception', payload['data']['body']['trace_chain'][1])
+        self.assertEqual(payload['data']['body']['trace_chain'][1]['exception']['message'], 'bar')
+        self.assertEqual(payload['data']['body']['trace_chain'][1]['exception']['class'], 'CauseException')
+        self.assertEqual(payload['data']['body']['trace_chain'][1]['frames'][-1]['locals']['bar_local'], 'bar')
+
+    @mock.patch('rollbar.send_payload')
     def test_report_exception_with_context(self, send_payload):
         def _raise_context():
             bar_local = 'bar'


### PR DESCRIPTION
Fixes: https://github.com/rollbar/pyrollbar/issues/318

I implemented what I thought seemed like a fairly sensible way of breaking out of any potential circular path, and also pretty much copied & pasted a unit-test and modified slightly to fit.

I tested this myself on Python 2.7.16 and Python 3.6.6 (I also tested with `raise cause from cause` on Python 3).

Interestingly, Django has a similar problem, when `DEBUG = True`. And I just noticed that recently they patched it (see https://code.djangoproject.com/ticket/29393 and https://github.com/django/django/blob/400ec5125ec32e3b18d267bbb4f3aab09d741ce4/django/views/debug.py#L401).