### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -1,4 +1,4 @@
-"""
+r"""
 django-rollbar middleware
 
 There are two options for installing the Rollbar middleware. Both options
@@ -36,7 +36,7 @@ import re
 ROLLBAR = {
     'access_token': 'YOUR_TOKEN',
     'ignorable_404_urls': (
-        re.compile('/index\.php'),
+        re.compile(r'/index\.php'),
         re.compile('/foobar'),
     ),
 }


### PR DESCRIPTION
Importing `pyrollbar` into a Django application with `warnings` enabled displays a `DeprecationWarning` caused by an invalid escape sequence in the docstring. The culprit is a regex pattern being interpreted as a Python escape sequence. The docstring should be a raw string in order to avoid parsing of Python escape sequences, and the example itself should also be updated for the same reason.

Test plan:
`PYTHONDONTWRITEBYTECODE=true python3 -Wd -m rollbar.contrib.django.middleware`. 
Before patching the change, you should see the following warning:
```
/pyrollbar/rollbar/contrib/django/middleware.py:79: DeprecationWarning: invalid escape sequence \.
```