### PR TITLE
Fix Travis build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rollbar.egg-info/
 Pipfile
 Pipfile.lock
 .pytest_cache/
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ matrix:
 
 install:
   - pip install setuptools==39.2.0 --force-reinstall
+  - if [ $TRAVIS_PYTHON_VERSION == 3.3 ]; then pip install Werkzeug==0.14.1 --force-reinstall; fi
   - if [ -v FLASK_VERSION ]; then pip install Flask==$FLASK_VERSION; fi
   - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq; fi
   - if [ -v DJANGO_VERSION ]; then pip install Django==$DJANGO_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,7 @@ matrix:
       env: PYRAMID_VERSION=1.9.2
 
 install:
+  - pip install setuptools==39.2.0 --force-reinstall
   - if [ -v FLASK_VERSION ]; then pip install Flask==$FLASK_VERSION; fi
   - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq; fi
   - if [ -v DJANGO_VERSION ]; then pip install Django==$DJANGO_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,16 @@ matrix:
     - python: "2.7"
       env: FLASK_VERSION=1.0.2
     - python: "3.3"
+      dist: trusty
       env: FLASK_VERSION=0.10.1
     - python: "3.3"
+      dist: trusty
       env: FLASK_VERSION=0.11.1
     - python: "3.3"
+      dist: trusty
       env: FLASK_VERSION=0.12.4
     - python: "3.3"
+      dist: trusty
       env: FLASK_VERSION=1.0.2
     - python: "3.4"
       env: FLASK_VERSION=0.10.1
@@ -76,8 +80,10 @@ matrix:
       env: DJANGO_VERSION=1.11.20
 
     - python: "3.3"
+      dist: trusty
       env: DJANGO_VERSION=1.6.11
     - python: "3.3"
+      dist: trusty
       env: DJANGO_VERSION=1.8.19
 
     - python: "3.4"

--- a/rollbar/test/flask_tests/test_flask.py
+++ b/rollbar/test/flask_tests/test_flask.py
@@ -102,7 +102,15 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('request', data)
             self.assertEqual(data['request']['url'], 'http://localhost/cause_error?foo=bar')
-            self.assertDictEqual(data['request']['GET'], {'foo': ['bar']})
+
+            # The behavior of implicitly converting werkzeug.ImmutableMultiDict
+            # using dict() changes starting in Python 3.6.
+            # See _build_werkzeug_request_data()
+            if sys.version_info >= (3, 6):
+                self.assertDictEqual(data['request']['GET'], {'foo': 'bar'})
+            else:
+                self.assertDictEqual(data['request']['GET'], {'foo': ['bar']})
+
             self.assertEqual(data['request']['user_ip'], '1.2.3.4')
             self.assertEqual(data['request']['method'], 'GET')
             self.assertEqual(data['request']['headers']['User-Agent'], 'Flask Test')
@@ -157,7 +165,15 @@ if ALLOWED_PYTHON_VERSION and FLASK_INSTALLED:
 
             self.assertIn('request', data)
             self.assertEqual(data['request']['url'], 'http://localhost/cause_error?foo=bar')
-            self.assertDictEqual(data['request']['GET'], {'foo': ['bar']})
+
+            # The behavior of implicitly converting werkzeug.ImmutableMultiDict
+            # using dict() changes starting in Python 3.6.
+            # See _build_werkzeug_request_data()
+            if sys.version_info >= (3, 6):
+                self.assertDictEqual(data['request']['GET'], {'foo': 'bar'})
+            else:
+                self.assertDictEqual(data['request']['GET'], {'foo': ['bar']})
+
             self.assertEqual(data['request']['user_ip'], '1.2.3.4')
             self.assertEqual(data['request']['method'], 'GET')
             self.assertEqual(data['request']['headers']['User-Agent'], 'Flask Test')

--- a/rollbar/test/flask_tests/test_flask.py
+++ b/rollbar/test/flask_tests/test_flask.py
@@ -6,7 +6,11 @@ import json
 import sys
 import os
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import rollbar
 
 from rollbar.test import BaseTest

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -4,8 +4,12 @@ Tests for the RollbarHandler logging handler
 import copy
 import json
 import logging
-import mock
 import sys
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import rollbar
 from rollbar.logger import RollbarHandler

--- a/rollbar/test/test_pyramid.py
+++ b/rollbar/test/test_pyramid.py
@@ -1,4 +1,7 @@
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from rollbar.test import BaseTest
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -1,12 +1,16 @@
 import base64
 import copy
 import json
-import mock
 import socket
 import threading
 import uuid
 
 import sys
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 try:
     from StringIO import StringIO

--- a/rollbar/test/twisted_tests/test_twisted.py
+++ b/rollbar/test/twisted_tests/test_twisted.py
@@ -5,7 +5,11 @@ Tests for Twisted instrumentation
 import json
 import sys
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import rollbar
 
 # access token for https://rollbar.com/rollbar/pyrollbar

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ with open(INIT_PATH) as fd:
     VERSION = re.search(r"^__version__ = ['\"]([^'\"]+)['\"]", INIT_DATA, re.MULTILINE).group(1)
 
 tests_require = [
-    'mock',
     'webob',
     'blinker',
     'unittest2'
@@ -26,6 +25,7 @@ tests_require = [
 
 version = sys.version_info
 if version[0] == 2 or (version[0] == 3 and version[1] < 4):
+    tests_require.append('mock<=3.0.5') # mock > 3.0.5 requires python >= 3.5
     tests_require.append('enum34')
 
 setup(


### PR DESCRIPTION
Werkzeug (1.0) and mock (4.0) are recently released major version releases that caused a variety of travis issues. Also, python 3.3 needs to run on trusty now, which required a few setup changes. 

- [x] Ubuntu Xenial can't find Python 3.3 any longer. Try using Trusty.
- [x] Some 3.x versions don't work well with `mock`, so use `unittest.mock`.
- [x] Implicit conversion using `dict()` changes behavior in python >= 3.6.
- [x] Ensure tested setuptools version. (Trusty doesn't have setuptools by default, and latest setuptools (45.x) produces errors that need to be addressed.)
- [x] Python 3.3 needs a compatible werkzeug version (0.14.1).