### PR TITLE
update travis testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,140 +1,36 @@
-sudo: false
 language: python
+
+python:
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+
+env:
+  - FLASK_VERSION=1.1.2
+  - FLASK_VERSION=1.0.4
+  - FLASK_VERSION=1.0.0
+
+  - TWISTED_VERSION=18.4.0
+  - TWISTED_VERSION=18.9.0
+  - TWISTED_VERSION=19.2.1
+
+  - DJANGO_VERSION=2.0.13
+  - DJANGO_VERSION=2.1.15
+  - DJANGO_VERSION=2.2.12
+  - DJANGO_VERSION=3.0.5
+
+  - PYRAMID_VERSION=1.9.2
+  - PYRAMID_VERSION=1.9.4
+  - PYRAMID_VERSION=1.10.4
+
 matrix:
-  include:
-    - python: "2.7"
-      env: FLASK_VERSION=0.9
-    - python: "2.7"
-      env: FLASK_VERSION=0.10.1
-    - python: "2.7"
-      env: FLASK_VERSION=0.11.1
-    - python: "2.7"
-      env: FLASK_VERSION=0.12.4
-    - python: "2.7"
-      env: FLASK_VERSION=1.0.2
-    - python: "3.3"
-      dist: trusty
-      env: FLASK_VERSION=0.10.1
-    - python: "3.3"
-      dist: trusty
-      env: FLASK_VERSION=0.11.1
-    - python: "3.3"
-      dist: trusty
-      env: FLASK_VERSION=0.12.4
-    - python: "3.3"
-      dist: trusty
-      env: FLASK_VERSION=1.0.2
-    - python: "3.4"
-      env: FLASK_VERSION=0.10.1
-    - python: "3.4"
-      env: FLASK_VERSION=0.11.1
-    - python: "3.4"
-      env: FLASK_VERSION=0.12.4
-    - python: "3.4"
-      env: FLASK_VERSION=1.0.2
-    - python: "3.5"
-      env: FLASK_VERSION=0.10.1
-    - python: "3.5"
-      env: FLASK_VERSION=0.11.1
-    - python: "3.5"
-      env: FLASK_VERSION=0.12.4
-    - python: "3.5"
-      env: FLASK_VERSION=1.0.2
-    - python: "3.6"
-      env: FLASK_VERSION=0.10.1
-    - python: "3.6"
-      env: FLASK_VERSION=0.11.1
-    - python: "3.6"
-      env: FLASK_VERSION=0.12.4
-    - python: "3.6"
-      env: FLASK_VERSION=1.0.2
-
-    - python: "2.7"
-      env: TWISTED_VERSION=15.5.0
-    - python: "2.7"
-      env: TWISTED_VERSION=16.1.1
-    - python: "2.7"
-      env: TWISTED_VERSION=16.2.0
-    - python: "2.7"
-      env: TWISTED_VERSION=16.3.0
-    - python: "2.7"
-      env: TWISTED_VERSION=16.4.0
-    - python: "2.7"
-      env: TWISTED_VERSION=16.5.0
-    - python: "2.7"
-      env: TWISTED_VERSION=16.6.0
-    - python: "2.7"
-      env: TWISTED_VERSION=17.1.0
-
-    - python: "2.7"
-      env: DJANGO_VERSION=1.6.11
-    - python: "2.7"
-      env: DJANGO_VERSION=1.7.11
-    - python: "2.7"
-      env: DJANGO_VERSION=1.8.19
-    - python: "2.7"
-      env: DJANGO_VERSION=1.9.13
-    - python: "2.7"
-      env: DJANGO_VERSION=1.10.8
-    - python: "2.7"
-      env: DJANGO_VERSION=1.11.20
-
-    - python: "3.3"
-      dist: trusty
-      env: DJANGO_VERSION=1.6.11
-    - python: "3.3"
-      dist: trusty
-      env: DJANGO_VERSION=1.8.19
-
-    - python: "3.4"
-      env: DJANGO_VERSION=1.7.11
-    - python: "3.4"
-      env: DJANGO_VERSION=1.8.19
-    - python: "3.4"
-      env: DJANGO_VERSION=1.9.13
-    - python: "3.4"
-      env: DJANGO_VERSION=1.10.8
-    - python: "3.4"
-      env: DJANGO_VERSION=1.11.20
-    - python: "3.4"
-      env: DJANGO_VERSION=2.0.13
-
-    - python: "3.5"
-      env: DJANGO_VERSION=1.8.19
-    - python: "3.5"
-      env: DJANGO_VERSION=1.9.13
-    - python: "3.5"
-      env: DJANGO_VERSION=1.10.8
-    - python: "3.5"
-      env: DJANGO_VERSION=1.11.20
-    - python: "3.5"
-      env: DJANGO_VERSION=2.0.13
-    - python: "3.5"
-      env: DJANGO_VERSION=2.1.7
-
-    - python: "3.6"
-      env: DJANGO_VERSION=1.11.20
-    - python: "3.6"
-      env: DJANGO_VERSION=2.0.13
-    - python: "3.6"
-      env: DJANGO_VERSION=2.1.7
-
-    - python: "3.7"
-      env: DJANGO_VERSION=1.11.20
-      dist: xenial
-    - python: "3.7"
-      env: DJANGO_VERSION=2.0.13
-      dist: xenial
-    - python: "3.7"
-      env: DJANGO_VERSION=2.1.7
-      dist: xenial
-
-    - python: "3.6"
-      env: PYRAMID_VERSION=1.9.2
+  exclude:
+    - python: '3.5'
+      env: DJANGO_VERSION=3.0.5
 
 install:
-  - pip install setuptools==39.2.0 --force-reinstall
-  - if [ $TRAVIS_PYTHON_VERSION == 3.3 ]; then pip install Werkzeug==0.14.1 --force-reinstall; fi
+  - pip install -U pip setuptools wheel
   - if [ -v FLASK_VERSION ]; then pip install Flask==$FLASK_VERSION; fi
   - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq; fi
   - if [ -v DJANGO_VERSION ]; then pip install Django==$DJANGO_VERSION; fi


### PR DESCRIPTION
- only test against supported versions of Python (≥ 3.5)
- only test against library versions that are at most 2 years old

Note: This PR **does not** update the supported versions, and that may be appropriate.