### PR TITLE
allow dict_merge to throw an error on rollbar.init + fix logging init

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -691,7 +691,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
         if not isinstance(extra_data, dict):
             extra_data = {'value': extra_data}
         if extra_trace_data:
-            extra_data = dict_merge(extra_data, extra_trace_data)
+            extra_data = dict_merge(extra_data, extra_trace_data, silence_errors=True)
         data['custom'] = extra_data
     if extra_trace_data and not extra_data:
         data['custom'] = extra_trace_data
@@ -703,7 +703,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
     data['server'] = _build_server_data()
 
     if payload_data:
-        data = dict_merge(data, payload_data)
+        data = dict_merge(data, payload_data, silence_errors=True)
 
     payload = _build_payload(data)
     send_payload(payload, payload.get('access_token'))
@@ -783,7 +783,7 @@ def _report_message(message, level, request, extra_data, payload_data):
     data['server'] = _build_server_data()
 
     if payload_data:
-        data = dict_merge(data, payload_data)
+        data = dict_merge(data, payload_data, silence_errors=True)
 
     payload = _build_payload(data)
     send_payload(payload, payload.get('access_token'))
@@ -1014,7 +1014,7 @@ def _add_lambda_context_data(data):
             }
         }
         if 'custom' in data:
-            data['custom'] = dict_merge(data['custom'], lambda_data)
+            data['custom'] = dict_merge(data['custom'], lambda_data, silence_errors=True)
         else:
             data['custom'] = lambda_data
     except Exception as e:

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -166,7 +166,7 @@ def is_builtin_type(obj):
 
 
 # http://www.xormedia.com/recursively-merge-dictionaries-in-python.html
-def dict_merge(a, b):
+def dict_merge(a, b, silence_errors=False):
     """
     Recursively merges dict's. not just simple a['key'] = b['key'], if
     both a and bhave a key who's value is a dict then dict_merge is called
@@ -179,11 +179,14 @@ def dict_merge(a, b):
     result = a
     for k, v in b.items():
         if k in result and isinstance(result[k], dict):
-            result[k] = dict_merge(result[k], v)
+            result[k] = dict_merge(result[k], v, silence_errors=silence_errors)
         else:
             try:
                 result[k] = copy.deepcopy(v)
             except:
+                if not silence_errors:
+                    raise six.reraise(*sys.exc_info())
+
                 result[k] = '<Uncopyable obj:(%s)>' % (v,)
 
     return result

--- a/rollbar/test/test_lib.py
+++ b/rollbar/test/test_lib.py
@@ -50,7 +50,7 @@ class RollbarLibTest(BaseTest):
         p = poll()
         a = {'a': {'b': 42}}
         b = {'a': {'y': p}}
-        result = dict_merge(a, b)
+        result = dict_merge(a, b, silence_errors=True)
 
         self.assertIn('a', result)
         self.assertIn('b', result['a'])


### PR DESCRIPTION
- ``dict_merge`` is used in ``rollbar.init`` which potentially allows broken config to silently misconfigure the rollbar settings because it is not strictly copying the config passed in. This PR changes ``dict_merge`` to allow a strict mode so ``rollbar.init`` will throw an error instead of misconfiguring rollbar, and when ``dict_merge`` is used to send data to rollbar it uses the unstrict mode to not break at "runtime".

- When initializing rollbar via the ``RollbarHandler``, the logging config that is passed in is wrapped by a ``Converting{Dict,List,Tuple}`` which breaks ``copy.deepcopy``. This PR unwraps the converter container types to their base types so that the subsequent call to ``dict_merge`` does not break or hide this error.