### PR TITLE
fix deque test's expected repr()

### DIFF
--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -6,6 +6,7 @@ import six
 from rollbar import DEFAULT_LOCALS_SIZES
 from rollbar.lib import transforms
 from rollbar.lib.transforms.shortener import ShortenerTransform
+from rollbar.lib.traverse import Sequence
 from rollbar.test import BaseTest
 
 
@@ -106,7 +107,7 @@ class ShortenerTransformTest(BaseTest):
 
     def test_shorten_deque(self):
         expected = 'deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...])'
-        if sys.version_info >= (3, 5):
+        if issubclass(deque, Sequence):
             expected = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]'
         self._assert_shortened('deque', expected)
 


### PR DESCRIPTION
In Python > 3.5 the `deque` class is registered as a `MutableSequence` https://github.com/python/cpython/blob/3.5/Lib/collections/__init__.py#L39, and this is already handled as a special case. This also affects Python 2.7 if the backported `typing` module is imported. As it becomes more and more likely a Python library on PyPI is typed, this is likely to continue to be a moving target.

Currently, it looks like the twisted test case relies on `treq`, which relies on `hyperlink`, which will import the `typing` module.