### PR TITLE
Use compatible treq version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,7 @@ install:
   - pip install setuptools==39.2.0 --force-reinstall
   - if [ $TRAVIS_PYTHON_VERSION == 3.3 ]; then pip install Werkzeug==0.14.1 --force-reinstall; fi
   - if [ -v FLASK_VERSION ]; then pip install Flask==$FLASK_VERSION; fi
-  - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq; fi
+  - if [ -v TWISTED_VERSION ]; then pip install Twisted==$TWISTED_VERSION treq==20.4.1; fi
   - if [ -v DJANGO_VERSION ]; then pip install Django==$DJANGO_VERSION; fi
   - if [ -v PYRAMID_VERSION ]; then pip install pyramid==$PYRAMID_VERSION; fi
 


### PR DESCRIPTION
## Description of the change

treq 20.9, released 11 days ago, will not import for Twisted <16.4. This PR pins treq to 20.4.1, which works with all currently tested versions of Twisted.

The change mainly affects Travis (or local testing for older Twisted versions), as users will have a treq that matches their Twisted version. (For local development: `pip install 'treq==20.4.1'`)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/rollbar/pyrollbar/pull/354

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
