### PR TITLE
Add a context manager object and a method to call said object

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -536,6 +536,10 @@ def wait(f=None):
         return f()
 
 
+def watch(flag_key):
+    return _FeatureFlagContextManager(flag_key)
+
+
 class ApiException(Exception):
     """
     This exception will be raised if there was a problem decoding the
@@ -1617,7 +1621,7 @@ def _wsgi_extract_user_ip(environ):
     return environ['REMOTE_ADDR']
 
 
-class FeatureFlags(object):
+class _FeatureFlagContextManager(object):
     def __init__(self, flag_key):
         self.flag_key = flag_key
         self.previous = feature_flags_data
@@ -1634,5 +1638,3 @@ class FeatureFlags(object):
 
         if not exc_type:
             feature_flags_data = self.previous
-
-

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -537,7 +537,7 @@ def wait(f=None):
 
 
 def watch(flag_key):
-    return _FeatureFlagContextManager(flag_key)
+    return FeatureFlags(flag_key)
 
 
 class ApiException(Exception):
@@ -1621,7 +1621,7 @@ def _wsgi_extract_user_ip(environ):
     return environ['REMOTE_ADDR']
 
 
-class _FeatureFlagContextManager(object):
+class FeatureFlags(object):
     def __init__(self, flag_key):
         self.flag_key = flag_key
         self.previous = feature_flags_data

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1619,7 +1619,7 @@ def _wsgi_extract_user_ip(environ):
 
 
 class FeatureFlags(object):
-    def __init__(self, flag_key, default):
+    def __init__(self, flag_key, default=False):
         self.flag_key = flag_key
     
     def __enter__(self):
@@ -1629,7 +1629,7 @@ class FeatureFlags(object):
             log.info('Launch Darkly not available')
             return
         
-        variation = ldclient.get().variation(self.flag_key, {}, False)
+        variation = ldclient.get().variation(self.flag_key, {}, default)
 
         global feature_flags_data
         

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1619,7 +1619,7 @@ def _wsgi_extract_user_ip(environ):
 
 
 class FeatureFlags(object):
-    def __init__(self, flag_key):
+    def __init__(self, flag_key, default):
         self.flag_key = flag_key
     
     def __enter__(self):
@@ -1629,7 +1629,7 @@ class FeatureFlags(object):
             log.info('Launch Darkly not available')
             return
         
-        variation = ldclient.get().variation(self.flag_key)
+        variation = ldclient.get().variation(self.flag_key, {}, False)
 
         global feature_flags_data
         

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -704,7 +704,6 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
 
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    feature_flags_data = {}
     
     request = _get_actual_request(request)
     _add_request_data(data, request)
@@ -794,7 +793,6 @@ def _report_message(message, level, request, extra_data, payload_data):
     
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    feature_flags_data = {}
 
     if payload_data:
         data = dict_merge(data, payload_data, silence_errors=True)
@@ -1633,10 +1631,11 @@ class FeatureFlags(object):
         variation = ldclient.get().variation(self.flag_key, {}, self.default)
 
         global feature_flags_data
-        
-        feature_flags_data[self.flag_key] = {
-            'variation': variation,
-            # maybe we could use some more data, leaving as placeholder
+        feature_flags_data = {
+            self.flag_key: {
+                'variation': variation,
+                # placeholder for more data
+            }
         }
 
         return  variation

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -704,7 +704,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
 
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    feature_flags_data = {}
+    # feature_flags_data = {}
     
     request = _get_actual_request(request)
     _add_request_data(data, request)
@@ -794,7 +794,7 @@ def _report_message(message, level, request, extra_data, payload_data):
     
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    feature_flags_data = {}
+    # feature_flags_data = {}
 
     if payload_data:
         data = dict_merge(data, payload_data, silence_errors=True)

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1617,8 +1617,12 @@ def _wsgi_extract_user_ip(environ):
 
 
 class FeatureFlags(object):
-    def __init__(self, flag_key, default=False):
+    def __init__(self, flag_key, user=None, default=False):
+        if not user:
+            user = {}
+
         self.flag_key = flag_key
+        self.user = user
         self.default = default
     
     def __enter__(self):
@@ -1628,7 +1632,8 @@ class FeatureFlags(object):
             log.info('Launch Darkly not available')
             return
         
-        variation = ldclient.get().variation(self.flag_key, {}, self.default)
+        # use get to retrieve ld singleton
+        variation = ldclient.get().variation(self.flag_key, self.user, self.default)
 
         global feature_flags_data
         feature_flags_data = {

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -704,7 +704,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
 
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    # feature_flags_data = {}
+    feature_flags_data = {}
     
     request = _get_actual_request(request)
     _add_request_data(data, request)
@@ -794,7 +794,7 @@ def _report_message(message, level, request, extra_data, payload_data):
     
     global feature_flags_data
     data['feature_flags'] = feature_flags_data
-    # feature_flags_data = {}
+    feature_flags_data = {}
 
     if payload_data:
         data = dict_merge(data, payload_data, silence_errors=True)
@@ -1642,6 +1642,9 @@ class FeatureFlags(object):
         return  variation
     
     def __exit__(self, type, value, traceback):
+        if issubclass(type, Exception):
+            return
+
         global feature_flags_data
         del feature_flags_data[self.flag_key]
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1621,6 +1621,7 @@ def _wsgi_extract_user_ip(environ):
 class FeatureFlags(object):
     def __init__(self, flag_key, default=False):
         self.flag_key = flag_key
+        self.default = default
     
     def __enter__(self):
         try:
@@ -1629,7 +1630,7 @@ class FeatureFlags(object):
             log.info('Launch Darkly not available')
             return
         
-        variation = ldclient.get().variation(self.flag_key, {}, default)
+        variation = ldclient.get().variation(self.flag_key, {}, self.default)
 
         global feature_flags_data
         


### PR DESCRIPTION
## Description of the change

Introduce `watch` method to wrap the calling of the context manager. The context manager `_BigBrother` handles adding `scope` objects to the stack when the code flow enters the context manager and removing the most recent `scope` object when exiting the context manager without an exception. If there is an exception, the most recent `scope` object will be added to the root level of the raw item payload and be sent under the key `scope`.

> Description here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
