### PR TITLE
Update CI badge from travis to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Pyrollbar CI
 on:
   push:
     branches: [ master ]
+    tags: [ v* ]
   pull_request:
     branches: [ master ]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pyrollbar
-![Build Status](https://github.com/rollbar/pyrollbar/workflows/Pyrollbar%20CI/badge.svg?branch=v0.15.1)
+![Build Status](https://github.com/rollbar/pyrollbar/workflows/Pyrollbar%20CI/badge.svg?tag=latest)
 
 Python notifier for reporting exceptions, errors, and log messages to [Rollbar](https://rollbar.com).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pyrollbar
-[![Build Status](https://travis-ci.org/rollbar/pyrollbar.svg?branch=v0.15.0)](https://travis-ci.org/rollbar/pyrollbar)
+![Build Status](https://github.com/rollbar/pyrollbar/workflows/Pyrollbar%20CI/badge.svg?branch=v0.15.1)
 
 Python notifier for reporting exceptions, errors, and log messages to [Rollbar](https://rollbar.com).
 
@@ -11,7 +11,7 @@ Python notifier for reporting exceptions, errors, and log messages to [Rollbar](
 # Usage and Reference
 
 For complete usage instructions and configuration reference, see our [Python SDK docs](https://docs.rollbar.com/docs/python).
-  
+
 # Release History & Changelog
 
 See our [Releases](https://github.com/rollbar/pyrollbar/releases) page for a list of all releases, including changes.


### PR DESCRIPTION
## Description of the change

Update the CI badge in the README to work with Github CI.

The existing release process requires manually updating the version in the status URL. This PR preserves that expectation.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
