### PR TITLE
Update CI dependencies for Twisted framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
           - FLASK_VERSION=0.11.1
           - FLASK_VERSION=0.12.4
           - FLASK_VERSION=1.0.2
-          - TWISTED_VERSION=15.5.0
-          - TWISTED_VERSION=16.1.0
-          - TWISTED_VERSION=16.2.0
-          - TWISTED_VERSION=16.3.0
-          - TWISTED_VERSION=16.4.0
-          - TWISTED_VERSION=16.5.0
-          - TWISTED_VERSION=16.6.0
-          - TWISTED_VERSION=17.1.0
+          - TWISTED_VERSION=15.5.0 treq==15.1.0
+          - TWISTED_VERSION=16.1.0 treq==16.12.0
+          - TWISTED_VERSION=16.2.0 treq==16.12.0
+          - TWISTED_VERSION=16.3.0 treq==16.12.0
+          - TWISTED_VERSION=16.4.0 treq==17.8.0
+          - TWISTED_VERSION=16.5.0 treq==17.8.0
+          - TWISTED_VERSION=16.6.0 treq==17.8.0
+          - TWISTED_VERSION=17.1.0 treq==20.4.1
           - DJANGO_VERSION=1.11.20
           - DJANGO_VERSION=2.0.13
           - DJANGO_VERSION=2.1.7
@@ -48,6 +48,44 @@ jobs:
             framework: DJANGO_VERSION=2.1.15
           - python-version: 3.7
             framework: DJANGO_VERSION=2.1.15
+
+          # twisted/treq setup.py allows:
+          # Twisted < 18.7.0 on python < 3.7
+          # Twisted >= 18.7.0 on python >= 3.7
+          # So we put twisted < 18.x in the matrix
+          # and disallow python 3.7 and 3.8 here.
+          - python-version: 3.7
+            framework: TWISTED_VERSION=15.5.0 treq==15.1.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.1.0 treq==16.12.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.2.0 treq==16.12.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.3.0 treq==16.12.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.4.0 treq==17.8.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.5.0 treq==17.8.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=16.6.0 treq==17.8.0
+          - python-version: 3.7
+            framework: TWISTED_VERSION=17.1.0 treq==20.4.1
+          - python-version: 3.8
+            framework: TWISTED_VERSION=15.5.0 treq==15.1.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.1.0 treq==16.12.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.2.0 treq==16.12.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.3.0 treq==16.12.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.4.0 treq==17.8.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.5.0 treq==17.8.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=16.6.0 treq==17.8.0
+          - python-version: 3.8
+            framework: TWISTED_VERSION=17.1.0 treq==20.4.1
         include:
           - python-version: 2.7
             framework: FLASK_VERSION=0.9
@@ -77,9 +115,18 @@ jobs:
             framework: DJANGO_VERSION=1.9.13
           - python-version: 3.5
             framework: DJANGO_VERSION=1.10.8
+          - python-version: 3.7
+            framework: TWISTED_VERSION=18.9.0 treq==20.4.1
+          - python-version: 3.7
+            framework: TWISTED_VERSION=19.10.0 treq==20.4.1
+          - python-version: 3.7
+            framework: TWISTED_VERSION=20.3.0 treq==20.4.1
           - python-version: 3.8
-            framework: TWISTED_VERSION=20.3.0
-
+            framework: TWISTED_VERSION=18.9.0 treq==20.4.1
+          - python-version: 3.8
+            framework: TWISTED_VERSION=19.10.0 treq==20.4.1
+          - python-version: 3.8
+            framework: TWISTED_VERSION=20.3.0 treq==20.4.1
     steps:
       - uses: actions/checkout@v2
         with:
@@ -106,7 +153,7 @@ jobs:
 
       - name: Install Twisted
         if: ${{ contains(matrix.framework, 'TWISTED_VERSION') }}
-        run: pip install Twisted==$TWISTED_VERSION treq==20.4.1
+        run: pip install Twisted==$TWISTED_VERSION idna==2.10
 
       - name: Install Django
         if: ${{ contains(matrix.framework, 'DJANGO_VERSION') }}


### PR DESCRIPTION
## Description of the change

### 1) This PR pins idna to 2.10.
Twisted CI builds broke since the last merged PR (Nov 10) because the `idna` package v3.0 released 24 days ago (https://github.com/kjd/idna/tree/v3.0) was picked up by the CI builds because idna wasn't pinned to a version. The build breaks because the `requests` package requires idna < 3.x. (https://github.com/psf/requests/blob/v2.25.1/setup.py#L44-L50)

### 2) This PR excludes some combinations of Python and Twisted versions.
The setup.py for `treq==20.4.1` doesn't allow Twisted >= 18.7.0 on python < 3.7, and doesn't allow Twisted < 18.7.0 on python >= 3.7. Some of the entries in the previous matrix should already have been failing, but passed previously in CI and passed for me locally. Those same combinations of Twisted and Python versions now fail for me locally, whereas they didn't before. I don't have much insight into what pip is doing differently now, but I've trimmed the matrix to what people at Twisted seem to think is safe. (Other versions of treq would allow some of the combinations to build, but for this build matrix, I don't see the point in chasing it.)

### 3) This PR pins treq to "best" versions for each Twisted
Using treq's `install_requires` and the release dates of versions I've tried to pair compatible versions of treq with the older Twisted versions. 

### 4) This PR adds Twisted 18 and 19 to the matrix
Over time, Twisted 18.x and 19.x haven't been added to the matrix. I went ahead and added the latest minor versions.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore: Non-code upkeep CI, docs, release scripts, etc.

## Related issues

Fixes: https://github.com/rollbar/pyrollbar/pull/360/

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
