### PR TITLE
fix missing locals shortening on items with "trace_chain" instead of "trace"

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -362,10 +362,11 @@ def init(access_token, environment='production', scrub_fields=None, url_fields=N
     ]
 
     if SETTINGS['locals']['enabled']:
-        shortener_keys.append(('body', 'trace', 'frames', '*', 'code'))
-        shortener_keys.append(('body', 'trace', 'frames', '*', 'args', '*'))
-        shortener_keys.append(('body', 'trace', 'frames', '*', 'kwargs', '*'))
-        shortener_keys.append(('body', 'trace', 'frames', '*', 'locals', '*'))
+        for prefix in (('body', 'trace'), ('body', 'trace_chain', '*')):
+            shortener_keys.append(prefix + ('frames', '*', 'code'))
+            shortener_keys.append(prefix + ('frames', '*', 'args', '*'))
+            shortener_keys.append(prefix + ('frames', '*', 'kwargs', '*'))
+            shortener_keys.append(prefix + ('frames', '*', 'locals', '*'))
 
     shortener_keys.extend(SETTINGS['shortener_keys'])
 


### PR DESCRIPTION
## Description of the change

In addition to shortening `trace`, `trace_chain` should also be shortened (and not cause a logged error about the payload being too large).

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
