### PR TITLE
Add Fastapi contrib

### DIFF
--- a/rollbar/contrib/fastapi/__init__.py
+++ b/rollbar/contrib/fastapi/__init__.py
@@ -1,0 +1,23 @@
+"""Integration with fastapi.
+
+See: https://fastapi.tiangolo.com/
+"""
+
+import rollbar
+
+from fastapi import Request
+
+
+def report_exception(request: Request):
+    rollbar.report_exc_info(request=request)
+
+
+def _hook(request, data):
+    data["framework"] = "fastapi"
+
+    if request:
+        endpoint = request.scope["endpoint"]
+        data["context"] = f"{endpoint.__module__}.{endpoint.__name__}"
+
+
+rollbar.BASE_DATA_HOOK = _hook

--- a/rollbar/examples/fastapi/app.py
+++ b/rollbar/examples/fastapi/app.py
@@ -1,0 +1,37 @@
+import rollbar
+import rollbar.contrib.fastapi
+import uvicorn
+
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse, Response
+
+app = FastAPI()
+
+
+rollbar.init("ACCESS_TOKEN", environment="development")
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected_exceptions(request: Request, exc: Exception):
+    """This won't capture HTTPException."""
+    try:
+        raise exc
+    except Exception:
+        rollbar.contrib.fastapi.report_exception(request=request)
+
+    return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@app.get("/")
+async def root(raise_exception: bool = False):
+    """Hello world api endpoint.
+
+    Use `?raise_exception=1` to raise an exception.
+    """
+    if raise_exception:
+        raise Exception("Testing exceptions")
+    return JSONResponse({"message": "Hello World"})
+
+
+if __name__ == "__main__":
+    uvicorn.run(app)

--- a/rollbar/test/fastapi_tests/test_fastapi.py
+++ b/rollbar/test/fastapi_tests/test_fastapi.py
@@ -1,0 +1,188 @@
+"""
+Tests for fastapi instrumentation
+"""
+
+import json
+import os
+import sys
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import rollbar
+from rollbar.test import BaseTest
+
+# access token for https://rollbar.com/rollbar/pyrollbar
+TOKEN = "92c10f5616944b81a2e6f3c6493a0ec2"
+
+# Fastapi works on python +3.6
+ALLOWED_PYTHON_VERSION = sys.version_info[0] == 3 and sys.version_info[1] >= 6
+
+
+try:
+    import fastapi  # noqa: F401
+
+    FASTAPI_INSTALLED = True
+except ImportError:
+    FASTAPI_INSTALLED = False
+
+
+def create_app():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    @app.get("/")
+    def index():
+        return "Index page"
+
+    @app.get("/cause_error")
+    @app.post("/cause_error")
+    def cause_error():
+        raise Exception("Uh oh")
+
+    return app
+
+
+def init_rollbar(app):
+    import rollbar.contrib.fastapi
+    from fastapi import Request, status
+    from fastapi.responses import Response
+
+    rollbar.init(
+        TOKEN,
+        "fastapitest",
+        root=os.path.dirname(os.path.realpath(__file__)),
+        allow_logging_basic_config=True,
+        capture_email=True,
+        capture_username=True,
+    )
+
+    @app.exception_handler(Exception)
+    async def handle_unexpected_exceptions(request: Request, exc: Exception):
+        """This won't capture HTTPException."""
+        try:
+            raise exc
+        except Exception:
+            rollbar.contrib.fastapi.report_exception(request=request)
+
+        return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+if ALLOWED_PYTHON_VERSION and FASTAPI_INSTALLED:
+
+    from fastapi.testclient import TestClient
+
+    class FastapiTest(BaseTest):
+        def setUp(self):
+            super().setUp()
+            self.app = create_app()
+            init_rollbar(self.app)
+            self.client = TestClient(self.app, raise_server_exceptions=False)
+
+        def test_index(self):
+            resp = self.client.get("/")
+            self.assertEqual(resp.status_code, 200)
+
+        def assertStringEqual(self, left, right):
+            if sys.version_info[0] > 2:
+                if hasattr(left, "decode"):
+                    left = left.decode("ascii")
+                if hasattr(right, "decode"):
+                    right = right.decode("ascii")
+
+                return self.assertEqual(left, right)
+            else:
+                return self.assertEqual(left, right)
+
+        @mock.patch("rollbar.send_payload")
+        def test_uncaught(self, send_payload):
+            resp = self.client.get(
+                "/cause_error?foo=bar",
+                headers={"X-Real-Ip": "1.2.3.4", "User-Agent": "Fastapi Test"},
+            )
+            self.assertEqual(resp.status_code, 500)
+
+            self.assertEqual(send_payload.called, True)
+            payload = send_payload.call_args[0][0]
+            data = payload["data"]
+
+            self.assertIn("body", data)
+            self.assertEqual(data["body"]["trace"]["exception"]["class"], "Exception")
+            self.assertStringEqual(
+                data["body"]["trace"]["exception"]["message"], "Uh oh"
+            )
+
+            self.assertIn("request", data)
+            self.assertEqual(
+                data["request"]["url"], "http://testserver/cause_error?foo=bar"
+            )
+
+            self.assertEqual(data["request"]["user_ip"], "1.2.3.4")
+            self.assertEqual(data["request"]["method"], "GET")
+            self.assertEqual(data["request"]["headers"]["user-agent"], "Fastapi Test")
+
+        @mock.patch("rollbar.send_payload")
+        def test_uncaught_json_request(self, send_payload):
+            json_body = {"hello": "world"}
+            json_body_str = json.dumps(json_body)
+            resp = self.client.post(
+                "/cause_error",
+                data=json_body_str,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Forwarded-For": "5.6.7.8",
+                },
+            )
+
+            self.assertEqual(resp.status_code, 500)
+
+            self.assertEqual(send_payload.called, True)
+            payload = send_payload.call_args[0][0]
+            data = payload["data"]
+
+            self.assertIn("body", data)
+            self.assertEqual(data["body"]["trace"]["exception"]["class"], "Exception")
+            self.assertStringEqual(
+                data["body"]["trace"]["exception"]["message"], "Uh oh"
+            )
+
+            self.assertIn("request", data)
+            self.assertEqual(data["request"]["url"], "http://testserver/cause_error")
+            self.assertEqual(data["request"]["user_ip"], "5.6.7.8")
+            self.assertEqual(data["request"]["method"], "POST")
+
+        @mock.patch("rollbar.send_payload")
+        def test_uncaught_no_username_no_email(self, send_payload):
+            rollbar.SETTINGS["capture_email"] = False
+            rollbar.SETTINGS["capture_username"] = False
+
+            resp = self.client.get(
+                "/cause_error?foo=bar",
+                headers={"X-Real-Ip": "1.2.3.4", "User-Agent": "Fastapi Test"},
+            )
+            self.assertEqual(resp.status_code, 500)
+
+            self.assertEqual(send_payload.called, True)
+            payload = send_payload.call_args[0][0]
+            data = payload["data"]
+
+            self.assertIn("body", data)
+            self.assertEqual(data["body"]["trace"]["exception"]["class"], "Exception")
+            self.assertStringEqual(
+                data["body"]["trace"]["exception"]["message"], "Uh oh"
+            )
+
+            self.assertIn("request", data)
+            self.assertEqual(
+                data["request"]["url"], "http://testserver/cause_error?foo=bar"
+            )
+
+            self.assertEqual(data["request"]["user_ip"], "1.2.3.4")
+            self.assertEqual(data["request"]["method"], "GET")
+            self.assertEqual(data["request"]["headers"]["user-agent"], "Fastapi Test")
+
+            rollbar.SETTINGS["capture_email"] = True
+            rollbar.SETTINGS["capture_username"] = True

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-import re
 import os.path
+import re
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -65,6 +66,7 @@ setup(
         "Framework :: Bottle",
         "Framework :: Django",
         "Framework :: Flask",
+        "Framework :: Fastapi",
         "Framework :: Pylons",
         "Framework :: Pyramid",
         "Framework :: Twisted",
@@ -81,5 +83,11 @@ setup(
         'requests>=0.12.1',
         'six>=1.9.0'
     ],
+    extra_requires={
+        "fastapi": [
+            "fastapi",
+            "uvicorn",
+        ],
+    },
     tests_require=tests_require,
     )


### PR DESCRIPTION
## Description of the change

Add basic support for fastapi. Since accessing the request data (body and GET/POST) is done via asynchronous methods I'm not sure how to implement that. Looks like older version of python are still supported so it'll have to wait... At least this PR can be used as a guide for people seeking setting up rollbar with fastapi.

## TODO

- [ ] Support adding `body` and `GET/POST` to request data
- [ ] Support adding `person` information

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
