### PR TITLE
Collect the user IP from X-Forwarded-For, then falls back to X-Real-Ip

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1605,13 +1605,12 @@ def _parse_response(path, access_token, params, resp, endpoint=None):
 
 
 def _extract_user_ip(request):
-    # some common things passed by load balancers... will need more of these.
-    real_ip = request.headers.get('X-Real-Ip')
-    if real_ip:
-        return real_ip
     forwarded_for = request.headers.get('X-Forwarded-For')
     if forwarded_for:
         return forwarded_for
+    real_ip = request.headers.get('X-Real-Ip')
+    if real_ip:
+        return real_ip
     return request.remote_addr
 
 


### PR DESCRIPTION
## Description of the change

The user IP will be taken from the X-Forwarded-For before checking X-Real-Ip to receive more accurate information if available.
Also, the current state of the sequence for checking the IP is not consistent across all supported frameworks.

This PR solves both issues.

I'm marking it as a _breaking change_ as the final user IP in a payload may be different in some cases. However, this change shouldn't affect user code, and in most cases shouldn't be even noticeable.


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
