### PR TITLE
Fix Python3.3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ jobs:
 
       - name: Python 3.3 dependencies
         if: ${{ matrix.python-version == '3.3' }}
-        run: pip install Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 enum34 --force-reinstall
+        run: pip install --force-reinstall \
+          Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 enum34 unittest2 blinker webob
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Python 3.3 dependencies
         if: ${{ matrix.python-version == '3.3' }}
-        run: pip install Werkzeug==0.14.1 --force-reinstall
+        run: pip install Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 --force-reinstall
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Python 3.3 dependencies
         if: ${{ matrix.python-version == '3.3' }}
-        run: pip install Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 --force-reinstall
+        run: pip install Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 enum34 --force-reinstall
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ tests_require = [
     'unittest2'
 ]
 
+if sys.version_info < (3, 3):
+    tests_require.append('mock<=3.0.5') # mock > 3.0.5 requires python >= 3.6
 if sys.version_info < (3, 4):
     tests_require.append('enum34')
-if sys.version_info < (3, 6):
-    tests_require.append('mock<=3.0.5') # mock > 3.0.5 requires python >= 3.6
 
 setup(
     name='rollbar',

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ tests_require = [
     'unittest2'
 ]
 
-version = sys.version_info
-if version[0] == 2 or (version[0] == 3 and version[1] < 4):
-    tests_require.append('mock<=3.0.5') # mock > 3.0.5 requires python >= 3.5
+if sys.version_info < (3, 4):
     tests_require.append('enum34')
+if sys.version_info < (3, 6):
+    tests_require.append('mock<=3.0.5') # mock > 3.0.5 requires python >= 3.6
 
 setup(
     name='rollbar',


### PR DESCRIPTION
## Description of the change

Python 3.3 builds have started to fail when running `python setup.py test` that cannot retrieve 3rd party packages anymore.

This PR addresses this issue.

It also includes a minor refactor on using correct version of the `mock` package:
Install `mock<=3.0.5` for Python 3.2- instead of Python 3.3- as `unittest.mock` has been added in Python3.3+

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [ch84510]

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
