### PR TITLE
Pin Werkzeug version for Flask 0.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
-          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
-          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
+          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
+          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
+          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1
-          - FLASK_VERSION=0.11.1
-          - FLASK_VERSION=0.12.4
+          - FLASK_VERSION=0.10.1 Jinja2>=2.4,<3.0
+          - FLASK_VERSION=0.11.1 Jinja2>=2.4,<3.0
+          - FLASK_VERSION=0.12.4 Jinja2>=2.4,<3.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2>=2.4,<3.0
-          - FLASK_VERSION=0.11.1 Jinja2>=2.4,<3.0
-          - FLASK_VERSION=0.12.4 Jinja2>=2.4,<3.0
+          - 'FLASK_VERSION=0.10.1 Jinja2>=2.4,<3.0'
+          - 'FLASK_VERSION=0.11.1 Jinja2>=2.4,<3.0'
+          - 'FLASK_VERSION=0.12.4 Jinja2>=2.4,<3.0'
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - 'FLASK_VERSION=0.10.1 Jinja2>=2.4,<3.0'
-          - 'FLASK_VERSION=0.11.1 Jinja2>=2.4,<3.0'
-          - 'FLASK_VERSION=0.12.4 Jinja2>=2.4,<3.0'
+          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0'
+          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0'
+          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0'
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
-          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
-          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
+          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
+          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
+          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\<1.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
-          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
-          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\>=0.7,\<1.0
+          - FLASK_VERSION=0.10.1 Werkzeug\>=0.7,\<1.0
+          - FLASK_VERSION=0.11.1 Werkzeug\>=0.7,\<1.0
+          - FLASK_VERSION=0.12.4 Werkzeug\>=0.7,\<1.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0
-          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0
-          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0
+          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
+          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
+          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0 Werkzeug\<2.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
         framework:
-          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0'
-          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0'
-          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0'
+          - FLASK_VERSION=0.10.1 Jinja2\>=2.4,\<3.0
+          - FLASK_VERSION=0.11.1 Jinja2\>=2.4,\<3.0
+          - FLASK_VERSION=0.12.4 Jinja2\>=2.4,\<3.0
           - FLASK_VERSION=1.0.2
           - TWISTED_VERSION=15.5.0 treq==15.1.0 zope.interface==4.1.3
           - TWISTED_VERSION=16.1.0 treq==16.12.0 zope.interface==4.1.3


### PR DESCRIPTION
## Description of the change

On May 11, 2021, Werkzeug released a new 2.x version that are not compatible with Flask 0.x.

This PR pins compatible Werkzeug version to Flask 0.x to fix build issues:
- Werkzeug >=0.7 and < 1.0

NOTE: We have successfully built `Flask 0.x` with `Werkzeug 1.x` so far, however according to the [upstream](https://github.com/pallets/flask/blob/0.12.x/setup.py#L74), `Flask 0.x` requires `Werkzeug >=0.7 and < 1.0`, so for sanity this PR uses the same requirements.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[ch85391]

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
