### PR TITLE
ASGI-family integration pre-release improvements

### DIFF
--- a/rollbar/contrib/asgi/middleware.py
+++ b/rollbar/contrib/asgi/middleware.py
@@ -1,9 +1,12 @@
+import logging
 import sys
 
 import rollbar
 from .integration import IntegrationBase, integrate
 from .types import ASGIApp, Receive, Scope, Send
 from rollbar.lib._async import RollbarAsyncError, try_report
+
+log = logging.getLogger(__name__)
 
 
 @integrate(framework_name='asgi')
@@ -23,5 +26,8 @@ class ReporterMiddleware(IntegrationBase):
                 try:
                     await try_report(exc_info)
                 except RollbarAsyncError:
+                    log.warning(
+                        'Failed to report asynchronously. Trying to report synchronously.'
+                    )
                     rollbar.report_exc_info(exc_info)
             raise

--- a/rollbar/contrib/fastapi/routing.py
+++ b/rollbar/contrib/fastapi/routing.py
@@ -94,6 +94,9 @@ class RollbarLoggingRoute(APIRoute):
                 try:
                     await try_report(exc_info, request)
                 except RollbarAsyncError:
+                    log.warning(
+                        'Failed to report asynchronously. Trying to report synchronously.'
+                    )
                     rollbar.report_exc_info(exc_info, request)
                 raise
 

--- a/rollbar/contrib/starlette/middleware.py
+++ b/rollbar/contrib/starlette/middleware.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 from starlette import __version__
@@ -9,6 +10,8 @@ from .requests import store_current_request
 from rollbar.contrib.asgi import ReporterMiddleware as ASGIReporterMiddleware
 from rollbar.contrib.asgi.integration import integrate
 from rollbar.lib._async import RollbarAsyncError, try_report
+
+log = logging.getLogger(__name__)
 
 
 @integrate(framework_name=f'starlette {__version__}')
@@ -35,5 +38,8 @@ class ReporterMiddleware(ASGIReporterMiddleware):
                 try:
                     await try_report(exc_info, request)
                 except RollbarAsyncError:
+                    log.warning(
+                        'Failed to report asynchronously. Trying to report synchronously.'
+                    )
                     rollbar.report_exc_info(exc_info, request)
             raise

--- a/rollbar/contrib/starlette/requests.py
+++ b/rollbar/contrib/starlette/requests.py
@@ -28,7 +28,7 @@ except ImportError:
 
 if ContextVar:
     _current_request: ContextVar[Optional[Request]] = ContextVar(
-        'request', default=None
+        'rollbar-request-object', default=None
     )
 
 

--- a/rollbar/examples/fastapi/app.py
+++ b/rollbar/examples/fastapi/app.py
@@ -50,7 +50,7 @@ async def localfunc(arg1, arg2, arg3):
 @app.get('/error')
 async def read_error():
     await localfunc('func_arg1', 'func_arg2', 1)
-    return {'result': "You shouldn't be seeing this")
+    return {'result': "You shouldn't be seeing this"}
 
 
 # Cause an uncaught exception to be sent to Rollbar
@@ -60,7 +60,7 @@ async def read_error():
 @app.post('/body')
 async def read_body():
     cause_error_with_body
-    return {'result': "You shouldn't be seeing this")
+    return {'result': "You shouldn't be seeing this"}
 
 
 # Cause an uncaught exception to be sent to Rollbar
@@ -70,7 +70,7 @@ async def read_body():
 @app.post('/form')
 async def read_form():
     cause_error_with_form
-    return {'result': "You shouldn't be seeing this")
+    return {'result': "You shouldn't be seeing this"}
 
 
 if __name__ == '__main__':

--- a/rollbar/examples/fastapi/app_middleware.py
+++ b/rollbar/examples/fastapi/app_middleware.py
@@ -50,7 +50,7 @@ async def localfunc(arg1, arg2, arg3):
 @app.get('/error')
 async def read_error():
     await localfunc('func_arg1', 'func_arg2', 1)
-    return {'result': "You shouldn't be seeing this")
+    return {'result': "You shouldn't be seeing this"}
 
 
 if __name__ == '__main__':

--- a/rollbar/lib/_async.py
+++ b/rollbar/lib/_async.py
@@ -39,7 +39,7 @@ except ImportError:
     ContextVar = None
 
 if ContextVar:
-    _ctx_handler = ContextVar('handler', default=None)
+    _ctx_handler = ContextVar('rollbar-handler', default=None)
 else:
     _ctx_handler = None
 

--- a/rollbar/test/asgi_tests/test_middleware.py
+++ b/rollbar/test/asgi_tests/test_middleware.py
@@ -101,10 +101,11 @@ class ReporterMiddlewareTest(BaseTest):
         self.assertFalse(sync_report_exc_info.called)
 
     @unittest2.skipUnless(ASYNC_REPORT_ENABLED, 'Requires Python 3.6+')
+    @mock.patch('logging.Logger.warning')
     @mock.patch('rollbar.lib._async.report_exc_info', new_callable=AsyncMock)
     @mock.patch('rollbar.report_exc_info')
     def test_should_use_sync_report_exc_info_if_non_async_handlers(
-        self, sync_report_exc_info, async_report_exc_info
+        self, sync_report_exc_info, async_report_exc_info, mock_log
     ):
         import rollbar
         from rollbar.contrib.asgi.middleware import ReporterMiddleware
@@ -118,6 +119,9 @@ class ReporterMiddlewareTest(BaseTest):
 
         self.assertFalse(async_report_exc_info.called)
         self.assertTrue(sync_report_exc_info.called)
+        mock_log.assert_called_once_with(
+            'Failed to report asynchronously. Trying to report synchronously.'
+        )
 
     def test_should_support_http_only(self):
         from rollbar.contrib.asgi.middleware import ReporterMiddleware

--- a/rollbar/test/async_tests/test_async.py
+++ b/rollbar/test/async_tests/test_async.py
@@ -518,6 +518,17 @@ class AsyncLibTest(BaseTest):
 
         async_report_exc_info.assert_not_called()
 
+    @mock.patch('rollbar.lib._async.httpx', None)
+    def test_try_report_should_raise_exc_if_httpx_package_is_missing(self):
+        import rollbar
+        from rollbar.lib._async import RollbarAsyncError, run, try_report
+
+        rollbar.SETTINGS['handler'] = 'httpx'
+        self.assertEqual(rollbar.SETTINGS['handler'], 'httpx')
+
+        with self.assertRaises(RollbarAsyncError):
+            run(try_report())
+
     @mock.patch('asyncio.ensure_future')
     def test_should_schedule_task_in_event_loop(self, ensure_future):
         from rollbar.lib._async import call_later, coroutine

--- a/rollbar/test/fastapi_tests/test_middleware.py
+++ b/rollbar/test/fastapi_tests/test_middleware.py
@@ -224,10 +224,11 @@ class ReporterMiddlewareTest(BaseTest):
         async_report_exc_info.assert_called_once()
         sync_report_exc_info.assert_not_called()
 
+    @mock.patch('logging.Logger.warning')
     @mock.patch('rollbar.lib._async.report_exc_info', new_callable=AsyncMock)
     @mock.patch('rollbar.report_exc_info')
     def test_should_use_sync_report_exc_info_if_non_async_handlers(
-        self, sync_report_exc_info, async_report_exc_info
+        self, sync_report_exc_info, async_report_exc_info, mock_log
     ):
         from fastapi import FastAPI
         import rollbar
@@ -253,6 +254,9 @@ class ReporterMiddlewareTest(BaseTest):
 
         sync_report_exc_info.assert_called_once()
         async_report_exc_info.assert_not_called()
+        mock_log.assert_called_once_with(
+            'Failed to report asynchronously. Trying to report synchronously.'
+        )
 
     @unittest2.skipUnless(
         sys.version_info >= (3, 6), 'Global request access requires Python 3.6+'

--- a/rollbar/test/fastapi_tests/test_routing.py
+++ b/rollbar/test/fastapi_tests/test_routing.py
@@ -367,10 +367,11 @@ class LoggingRouteTest(BaseTest):
         async_report_exc_info.assert_called_once()
         sync_report_exc_info.assert_not_called()
 
+    @mock.patch('logging.Logger.warning')
     @mock.patch('rollbar.lib._async.report_exc_info', new_callable=AsyncMock)
     @mock.patch('rollbar.report_exc_info')
     def test_should_use_sync_report_exc_info_if_non_async_handlers(
-        self, sync_report_exc_info, async_report_exc_info
+        self, sync_report_exc_info, async_report_exc_info, mock_log
     ):
         from fastapi import FastAPI
         import rollbar
@@ -396,6 +397,9 @@ class LoggingRouteTest(BaseTest):
 
         sync_report_exc_info.assert_called_once()
         async_report_exc_info.assert_not_called()
+        mock_log.assert_called_once_with(
+            'Failed to report asynchronously. Trying to report synchronously.'
+        )
 
     def test_should_enable_loading_route_handler_if_fastapi_version_is_sufficient(self):
         from fastapi import FastAPI

--- a/rollbar/test/starlette_tests/test_middleware.py
+++ b/rollbar/test/starlette_tests/test_middleware.py
@@ -202,10 +202,11 @@ class ReporterMiddlewareTest(BaseTest):
         async_report_exc_info.assert_called_once()
         sync_report_exc_info.assert_not_called()
 
+    @mock.patch('logging.Logger.warning')
     @mock.patch('rollbar.lib._async.report_exc_info', new_callable=AsyncMock)
     @mock.patch('rollbar.report_exc_info')
     def test_should_use_sync_report_exc_info_if_non_async_handlers(
-        self, sync_report_exc_info, async_report_exc_info
+        self, sync_report_exc_info, async_report_exc_info, mock_log
     ):
         from starlette.applications import Starlette
         from starlette.testclient import TestClient
@@ -227,6 +228,9 @@ class ReporterMiddlewareTest(BaseTest):
 
         sync_report_exc_info.assert_called_once()
         async_report_exc_info.assert_not_called()
+        mock_log.assert_called_once_with(
+            'Failed to report asynchronously. Trying to report synchronously.'
+        )
 
     @unittest2.skipUnless(
         sys.version_info >= (3, 6), 'Global request access requires Python 3.6+'


### PR DESCRIPTION
## Description of the change

1. Add warning message if asynchronous reporting fails
2. Rename `ContextVar` identifiers
3. Fix `SyntaxError` in FastAPI examples

[1] When using ASGI-family integration it **tries** to report asynchronously by default. The `try_report()` coroutine verifies the current settings for the handler. If the handler is explicitly set to any synchronous handler or HTTPX package is missing, it raises `RollbarAsyncError` exception and retries with synchronous reporting. This PR adds a warning message when `RollbarAsyncError` is raised.

Here are some actual scenarios:

**Condition:** `SETTINGS['handler'] == 'non_async_handler'`
**Action:**  report errors/messages via ASGI-family integrations
**Results:** warn before using explicitly set a non-async handler

**Condition 1:** `SETTINGS['handler'] == 'any_async_handler'`
**Condition 2:** HTTPX package is missing
**Action:**  report errors/messages via ASGI-family integrations
**Results:** log warning before failed back to sync reporting and fail (log error) due to missing HTTPX package

**Condition:** HTTPX package is missing
**Action:** directly report errors/messages (via `report_exc_info()` and `report_message()` awaitable coroutines)
**Results:** fail (log error) due to missing HTTPX package

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [ch86049]
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
