### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The change log is also available on the [GitHub Releases Page](https://github.com/rollbar/pyrollbar/releases).
 
+**0.16.1**
+
+- Fix PyPI artifacts
+
 **0.16.0**
 
 - Add support for FastAPI framework. See [#373](https://github.com/rollbar/pyrollbar/pull/373)

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -23,7 +23,7 @@ import six
 from rollbar.lib import events, filters, dict_merge, parse_qs, text, transport, urljoin, iteritems, defaultJSONEncode
 
 
-__version__ = '0.16.0'
+__version__ = '0.16.1'
 __log_name__ = 'rollbar'
 log = logging.getLogger(__log_name__)
 


### PR DESCRIPTION
## Description of the change

No changes since v0.16.0.
It's necessary to fix PyPI artifacts as v0.16.0 package was wrongly uploaded.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New release

## Related issues

> Fix #383 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
