### PR TITLE
fix #373 breaking collecting user information on *not* starlette

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -935,7 +935,7 @@ def _build_person_data(request):
     if StarletteRequest:
         from rollbar.contrib.starlette.requests import hasuser
     else:
-        hasuser = lambda request: True
+        def hasuser(request): return True
 
     if hasuser(request) and hasattr(request, 'user'):
         user_prop = request.user

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -935,7 +935,7 @@ def _build_person_data(request):
     if StarletteRequest:
         from rollbar.contrib.starlette.requests import hasuser
     else:
-        hasuser = lambda request: False
+        hasuser = lambda request: True
 
     if hasuser(request) and hasattr(request, 'user'):
         user_prop = request.user

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -337,7 +337,8 @@ class RollbarTest(BaseTest):
             settings.configure(
                 INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes']
             )
-            django.setup()
+            if django.VERSION >= (1, 7):
+                django.setup()
 
         from django.contrib.auth.models import User
         from django.http.request import HttpRequest

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import re
 import os.path
-import sys
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -78,8 +77,20 @@ setup(
         "Topic :: System :: Monitoring",
         ],
     install_requires=[
-        'requests>=0.12.1',
+        # The currently used version of `setuptools` has a bug,
+        # so the version requirements are not properly respected.
+        #
+        # In the current version, `requests>= 0.12.1`
+        # always installs the latest version of the package.
+        'requests>=0.12.1; python_version == "2.7"',
+        'requests>=0.12.1; python_version >= "3.6"',
+        'requests<2.26,>=0.12.1; python_version == "3.5"',
+        'requests<2.22,>=0.12.1; python_version == "3.4"',
+        'requests<2.19,>=0.12.1; python_version == "3.3"',
+        'requests<1.2,>=0.12.1; python_version == "3.2"',
+        'requests<1.2,>=0.12.1; python_version == "3.1"',
+        'requests<1.2,>=0.12.1; python_version == "3.0"',
         'six>=1.9.0'
     ],
     tests_require=tests_require,
-    )
+)


### PR DESCRIPTION
## Description of the change

The change fixes the check to match the previous code:

  `if not StarletteRequest and hasattr(request, 'user'):`


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
 
- fix [ch91323]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
