### PR TITLE
Fix CI builds by limiting `requests` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import re
 import os.path
-import sys
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -94,4 +93,4 @@ setup(
         'six>=1.9.0'
     ],
     tests_require=tests_require,
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,19 @@ setup(
         "Topic :: System :: Monitoring",
         ],
     install_requires=[
-        'requests>=0.12.1',
+        # The currently used version of `setuptools` has a bug,
+        # so the version requirements are not properly respected.
+        #
+        # In the current version, `requests>= 0.12.1`
+        # always installs the latest version of the package.
+        'requests>=0.12.1; python_version == "2.7"',
+        'requests>=0.12.1; python_version >= "3.6"',
+        'requests<2.26,>=0.12.1; python_version == "3.5"',
+        'requests<2.22,>=0.12.1; python_version == "3.4"',
+        'requests<2.19,>=0.12.1; python_version == "3.3"',
+        'requests<1.2,>=0.12.1; python_version == "3.2"',
+        'requests<1.2,>=0.12.1; python_version == "3.1"',
+        'requests<1.2,>=0.12.1; python_version == "3.0"',
         'six>=1.9.0'
     ],
     tests_require=tests_require,


### PR DESCRIPTION
## Description of the change

The latest version of 'requests` (v2.26.0) breaks our Python 3.4 builds. This is because it fails the compatibility check:
https://github.com/psf/requests/blob/a1a6a549a0143d9b32717dbe3d75cd543ae5a4f6/requests/__init__.py#L98-L104

This makes sense when you look here:
https://github.com/psf/requests/blob/a1a6a549a0143d9b32717dbe3d75cd543ae5a4f6/setup.py#L81

Our CI builds seem to always install the latest version regardless of requirements. This is due to a bug in `setuptools`, which does not respect the maximum version required for installing packages.

The error doesn't occur for Python 3.3 builds as they have a custom setup where `pip` is responsible for installing `requests` and it handles the requirements properly.
Python 3.5 passes the compatibility check however, this version is also unsupported and could potentially fail in the future.

This PR explicitly limits the maximum required `requests` version for each Python version.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix [ch91321]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
