### PR TITLE
Fix #387: recursive error logging for non-http events

### DIFF
--- a/rollbar/contrib/starlette/requests.py
+++ b/rollbar/contrib/starlette/requests.py
@@ -57,8 +57,10 @@ def store_current_request(
 
     if receive is None:
         request = request_or_scope
-    else:
+    elif request_or_scope['type'] == 'http':
         request = Request(request_or_scope, receive)
+    else:
+        request = None
 
     _current_request.set(request)
     return request

--- a/rollbar/contrib/starlette/requests.py
+++ b/rollbar/contrib/starlette/requests.py
@@ -46,13 +46,7 @@ def get_current_request() -> Optional[Request]:
         )
         return None
 
-    request = _current_request.get()
-
-    if request is None:
-        log.error('Request is not available in the present context.')
-        return None
-
-    return request
+    return _current_request.get()
 
 
 def store_current_request(

--- a/rollbar/test/starlette_tests/test_requests.py
+++ b/rollbar/test/starlette_tests/test_requests.py
@@ -51,7 +51,7 @@ class RequestTest(BaseTest):
 
         self.assertEqual(request, stored_request)
 
-    def test_should_accept_scope_and_receive_params(self):
+    def test_should_accept_scope_param_if_http_type(self):
         from starlette.requests import Request
         from rollbar.contrib.starlette.requests import store_current_request
         from rollbar.lib._async import async_receive
@@ -82,6 +82,16 @@ class RequestTest(BaseTest):
         request = store_current_request(scope, receive)
 
         self.assertEqual(request, expected_request)
+
+    def test_should_not_accept_scope_param_if_not_http_type(self):
+        from rollbar.contrib.starlette.requests import store_current_request
+
+        scope = {'asgi': {'spec_version': '2.0', 'version': '3.0'}, 'type': 'lifespan'}
+        receive = {}
+
+        request = store_current_request(scope, receive)
+
+        self.assertIsNone(request)
 
     def test_hasuser(self):
         from starlette.requests import Request

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import re
 import os.path
-import sys
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -94,4 +93,4 @@ setup(
         'six>=1.9.0'
     ],
     tests_require=tests_require,
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,19 @@ setup(
         "Topic :: System :: Monitoring",
         ],
     install_requires=[
-        'requests>=0.12.1',
+        # The currently used version of `setuptools` has a bug,
+        # so the version requirements are not properly respected.
+        #
+        # In the current version, `requests>= 0.12.1`
+        # always installs the latest version of the package.
+        'requests>=0.12.1; python_version == "2.7"',
+        'requests>=0.12.1; python_version >= "3.6"',
+        'requests<2.26,>=0.12.1; python_version == "3.5"',
+        'requests<2.22,>=0.12.1; python_version == "3.4"',
+        'requests<2.19,>=0.12.1; python_version == "3.3"',
+        'requests<1.2,>=0.12.1; python_version == "3.2"',
+        'requests<1.2,>=0.12.1; python_version == "3.1"',
+        'requests<1.2,>=0.12.1; python_version == "3.0"',
         'six>=1.9.0'
     ],
     tests_require=tests_require,


### PR DESCRIPTION
## Description of the change

This PR addresses an issue reported in #387.

In the current release, the SDK logs an error if a request object does not exist in the local context. This behavior leads to recursive error logging when `RollbarHandler` is used. The `RollbarHandler` tries to add the request object to the payload itself, so in the absence of a request in the local context, it again tries to log the error by using `RollbarHandler` and invokes `rollbar.get_request()` that again causes the same error.

The provided solution removes logging errors in case of missing a request in the local context. Instead, it returns `None`.
Additionally, the PR restricts the storage of request objects only for the ASGI-HTTP scope, so for other scopes, it blindly stores `None` without trying to create the request object itself.

I merged the PR #389 branch to pass CI tests. This PR should be merged after approval of #389.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- Fix #387
- Fix [ch91322]

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
