### PR TITLE
SC-95272: Remove support for Python 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,18 +134,6 @@ jobs:
         include:
           - python-version: 2.7
             framework: FLASK_VERSION=0.9
-          - python-version: 3.3
-            framework: FLASK_VERSION=0.10.1
-          - python-version: 3.3
-            framework: FLASK_VERSION=0.11.1
-          - python-version: 3.3
-            framework: FLASK_VERSION=0.12.4
-          - python-version: 3.3
-            framework: FLASK_VERSION=1.0.2
-          - python-version: 3.3
-            framework: DJANGO_VERSION=1.6.11
-          - python-version: 3.3
-            framework: DJANGO_VERSION=1.8.19
           - python-version: 3.4
             framework: DJANGO_VERSION=1.7.11
           - python-version: 3.4
@@ -184,11 +172,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install setuptools==39.2.0 --force-reinstall
-
-      - name: Python 3.3 dependencies
-        if: ${{ matrix.python-version == '3.3' }}
-        run: pip install --force-reinstall \
-          Werkzeug==0.14.1 six>=1.9.0 requests>=0.12.1 enum34 unittest2 blinker webob
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -85,10 +85,6 @@ setup(
         'requests>=0.12.1; python_version >= "3.6"',
         'requests<2.26,>=0.12.1; python_version == "3.5"',
         'requests<2.22,>=0.12.1; python_version == "3.4"',
-        'requests<2.19,>=0.12.1; python_version == "3.3"',
-        'requests<1.2,>=0.12.1; python_version == "3.2"',
-        'requests<1.2,>=0.12.1; python_version == "3.1"',
-        'requests<1.2,>=0.12.1; python_version == "3.0"',
         'six>=1.9.0'
     ],
     tests_require=tests_require,


### PR DESCRIPTION
## Description of the change

Python 3.3 reached its end-of-life on 2017-09-29 and it's no longer supported. It also requires `requests` package in an unsupported version with a security vulnerability.

See SC-95272 for more details on motivation and rationale.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance

## Related issues

- Fix [SC-95272]
 
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
