### PR TITLE
Add Django 4.0+ compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,14 @@ jobs:
           - TWISTED_VERSION=16.5.0 treq==16.12.0 zope.interface==4.5.0
           - TWISTED_VERSION=16.6.0 treq==16.12.0 zope.interface==4.5.0
           - TWISTED_VERSION=17.1.0 treq==16.12.0 zope.interface==4.5.0
-          - DJANGO_VERSION=1.11.20
+          - DJANGO_VERSION=1.11.29
           - DJANGO_VERSION=2.0.13
-          - DJANGO_VERSION=2.1.7
           - DJANGO_VERSION=2.1.15
+          - DJANGO_VERSION=2.2.26
+          - DJANGO_VERSION=3.0.14
+          - DJANGO_VERSION=3.1.14
+          - DJANGO_VERSION=3.2.11
+          - DJANGO_VERSION=4.0.1
           - PYRAMID_VERSION=1.9.2
           - PYRAMID_VERSION=1.10.4
           - STARLETTE_VERSION=0.12.12 httpx==0.18.1 python-multipart==0.0.5
@@ -42,18 +46,46 @@ jobs:
           - python-version: 2.7
             framework: DJANGO_VERSION=2.0.13
           - python-version: 2.7
-            framework: DJANGO_VERSION=2.1.7
+            framework: DJANGO_VERSION=2.1.15
           - python-version: 2.7
+            framework: DJANGO_VERSION=2.2.26
+          - python-version: 2.7
+            framework: DJANGO_VERSION=3.0.14
+          - python-version: 2.7
+            framework: DJANGO_VERSION=3.1.14
+          - python-version: 2.7
+            framework: DJANGO_VERSION=3.2.11
+          - python-version: 2.7
+            framework: DJANGO_VERSION=4.0.1
+          - python-version: 3.4
             framework: DJANGO_VERSION=2.1.15
           - python-version: 3.4
-            framework: DJANGO_VERSION=2.1.7
+            framework: DJANGO_VERSION=2.2.26
           - python-version: 3.4
-            framework: DJANGO_VERSION=2.1.15
+            framework: DJANGO_VERSION=3.0.14
+          - python-version: 3.4
+            framework: DJANGO_VERSION=3.1.14
+          - python-version: 3.4
+            framework: DJANGO_VERSION=3.2.11
+          - python-version: 3.4
+            framework: DJANGO_VERSION=4.0.1
           - python-version: 3.5
-            framework: DJANGO_VERSION=2.1.15
+            framework: DJANGO_VERSION=3.0.14
+          - python-version: 3.5
+            framework: DJANGO_VERSION=3.1.14
+          - python-version: 3.5
+            framework: DJANGO_VERSION=3.2.11
+          - python-version: 3.5
+            framework: DJANGO_VERSION=4.0.1
           - python-version: 3.6
-            framework: DJANGO_VERSION=2.1.15
+            framework: DJANGO_VERSION=4.0.1
           - python-version: 3.7
+            framework: DJANGO_VERSION=4.0.1
+          - python-version: 3.8
+            framework: DJANGO_VERSION=1.11.29
+          - python-version: 3.8
+            framework: DJANGO_VERSION=2.0.13
+          - python-version: 3.8
             framework: DJANGO_VERSION=2.1.15
 
           # twisted/treq setup.py allows:
@@ -134,20 +166,6 @@ jobs:
         include:
           - python-version: 2.7
             framework: FLASK_VERSION=0.9
-          - python-version: 3.4
-            framework: DJANGO_VERSION=1.7.11
-          - python-version: 3.4
-            framework: DJANGO_VERSION=1.8.19
-          - python-version: 3.4
-            framework: DJANGO_VERSION=1.9.13
-          - python-version: 3.4
-            framework: DJANGO_VERSION=1.10.8
-          - python-version: 3.5
-            framework: DJANGO_VERSION=1.8.19
-          - python-version: 3.5
-            framework: DJANGO_VERSION=1.9.13
-          - python-version: 3.5
-            framework: DJANGO_VERSION=1.10.8
           - python-version: 3.7
             framework: TWISTED_VERSION=18.9.0 treq==20.4.1 zope.interface==4.5.0
           - python-version: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,20 @@ jobs:
         include:
           - python-version: 2.7
             framework: FLASK_VERSION=0.9
+          - python-version: 3.4
+            framework: DJANGO_VERSION=1.7.11
+          - python-version: 3.4
+            framework: DJANGO_VERSION=1.8.19
+          - python-version: 3.4
+            framework: DJANGO_VERSION=1.9.13
+          - python-version: 3.4
+            framework: DJANGO_VERSION=1.10.8
+          - python-version: 3.5
+            framework: DJANGO_VERSION=1.8.19
+          - python-version: 3.5
+            framework: DJANGO_VERSION=1.9.13
+          - python-version: 3.5
+            framework: DJANGO_VERSION=1.10.8
           - python-version: 3.7
             framework: TWISTED_VERSION=18.9.0 treq==20.4.1 zope.interface==4.5.0
           - python-version: 3.7


### PR DESCRIPTION
## Description of the change

Django 4.0 introduces some changes designed to better handle frozen environments (see [here](https://github.com/django/django/commit/9ee693bd6cf4074f04ec51c6f3cfe87cad392f12#diff-eb948fbc65f2117752334d2fc61d04bfbb635aa3d91f7e1b652376efea04e658)) which broke the pyrollbar Django middleware. This change should allow pyrollbar to properly patch `ExceptionReporter.get_traceback_html` in _django.views.debug_ for Django 4.0+.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related Issues

- https://github.com/rollbar/pyrollbar/issues/399

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
