### PR TITLE
Limit number of elements processed by `traverse`

### DIFF
--- a/rollbar/lib/traverse.py
+++ b/rollbar/lib/traverse.py
@@ -92,6 +92,10 @@ def limited_enumerate(i, max):
     return enumerate(islice(i, 0, max))
 
 
+def limited_iteritems(dict, max):
+    return islice(iteritems(dict), 0, max)
+
+
 def traverse(obj,
              key=(),
              string_handler=_default_handlers[STRING],
@@ -139,13 +143,13 @@ def traverse(obj,
         elif obj_type is TUPLE:
             return tuple_handler(tuple(traverse(elem, key=key + (i,), **kw) for i, elem in limited_enumerate(obj, max_list)), key=key)
         elif obj_type is NAMEDTUPLE:
-            return namedtuple_handler(obj._make(traverse(v, key=key + (k,), **kw) for k, v in iteritems(obj._asdict())), key=key)
+            return namedtuple_handler(obj._make(traverse(v, key=key + (k,), **kw) for k, v in limited_iteritems(obj._asdict(), max_list)), key=key)
         elif obj_type is LIST:
             return list_handler(list(traverse(elem, key=key + (i,), **kw) for i, elem in limited_enumerate(obj, max_list)), key=key)
         elif obj_type is SET:
             return set_handler(set(traverse(elem, key=key + (i,), **kw) for i, elem in limited_enumerate(obj, max_list)), key=key)
         elif obj_type is MAPPING:
-            return mapping_handler(dict((k, traverse(v, key=key + (k,), **kw)) for k, v in iteritems(obj)), key=key)
+            return mapping_handler(dict((k, traverse(v, key=key + (k,), **kw)) for k, v in limited_iteritems(obj, max_list)), key=key)
         elif obj_type is DEFAULT:
             for handler_type, handler in iteritems(custom_handlers):
                 if isinstance(obj, handler_type):

--- a/rollbar/test/test_traverse.py
+++ b/rollbar/test/test_traverse.py
@@ -33,3 +33,12 @@ class RollbarTraverseTest(BaseTest):
     def test_bad_object(self):
         setattr(self.tuple, '_fields', 'not quite a named tuple')
         self.assertEqual(traverse(self.tuple), (1, 2, 3))
+
+class RollbarTraverseLimitTest(BaseTest):
+    def test_limits(self):
+        for input, expected in [
+            ([1, 2, 3, 4, 5], [1, 2, 3]),
+            ((1, 2, 3, 4, 5), (1, 2, 3))
+        ]:
+            result = traverse(input, max_list=3)
+            self.assertEqual(result, expected)

--- a/rollbar/test/test_traverse.py
+++ b/rollbar/test/test_traverse.py
@@ -38,7 +38,8 @@ class RollbarTraverseLimitTest(BaseTest):
     def test_limits(self):
         for input, expected in [
             ([1, 2, 3, 4, 5], [1, 2, 3]),
-            ((1, 2, 3, 4, 5), (1, 2, 3))
+            ((1, 2, 3, 4, 5), (1, 2, 3)),
+            (dict((i, i) for i in range(5)), dict((i, i) for i in range(3))),
         ]:
             result = traverse(input, max_list=3)
             self.assertEqual(result, expected)


### PR DESCRIPTION
## Description of the change

When rollbar is called, transformations are applied to arguments and local variables, which can contain large structures, leading to cpu and memory consumption (for example multi-gigabyte `memoryview` in locals).

This PR adds limit to maximum number of elements processed - so structures are effectively cropped past that limit.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
