### PR TITLE
Pinned Python 2 CI tests to legacy version of dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,13 @@ jobs:
       - name: Install dependencies
         run: pip install setuptools==39.2.0 --force-reinstall
 
+      - name: Install Python 2 dependencies
+        if: ${{ contains(matrix.python-version, '2.7') }}
+        # certifi dropped support for Python 2 in 2020.4.5.2 but only started
+        # using Python 3 syntax in 2022.5.18. 2021.10.8 is the last release with
+        # Python 2 support.
+        run: pip install certifi==2021.10.8
+
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Install Python 3.4 dependencies
         if: ${{ contains(matrix.python-version, '3.4') }}
         # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
-        run: pip install certifi==2021.10.8 typing-extensions==3.10.0.1
+        run: pip install certifi==2021.10.8
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,18 +205,6 @@ jobs:
       - name: Install dependencies
         run: pip install setuptools==39.2.0 --force-reinstall
 
-      - name: Install Python 2 dependencies
-        if: ${{ contains(matrix.python-version, '2.7') }}
-        # certifi dropped support for Python 2 in 2020.4.5.2 but only started
-        # using Python 3 syntax in 2022.5.18. 2021.10.8 is the last release with
-        # Python 2 support.
-        run: pip install certifi==2021.10.8
-
-      - name: Install Python 3.4 dependencies
-        if: ${{ contains(matrix.python-version, '3.4') }}
-        # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
-        run: pip install certifi==2021.10.8 typing-extensions==3.10.0.1
-
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV
 
@@ -243,6 +231,18 @@ jobs:
       - name: Install FastAPI
         if: ${{ contains(matrix.framework, 'FASTAPI_VERSION') }}
         run: pip install fastapi==$FASTAPI_VERSION
+
+      - name: Install Python 2 dependencies
+        if: ${{ contains(matrix.python-version, '2.7') }}
+        # certifi dropped support for Python 2 in 2020.4.5.2 but only started
+        # using Python 3 syntax in 2022.5.18. 2021.10.8 is the last release with
+        # Python 2 support.
+        run: pip install certifi==2021.10.8
+
+      - name: Install Python 3.4 dependencies
+        if: ${{ contains(matrix.python-version, '3.4') }}
+        # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
+        run: pip install certifi==2021.10.8 typing-extensions==3.10.0.1
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,11 @@ jobs:
         # Python 2 support.
         run: pip install certifi==2021.10.8
 
+      - name: Install Python 3.4 dependencies
+        if: ${{ contains(matrix.python-version, '3.4') }}
+        # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
+        run: pip install certifi==2021.10.8
+
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,17 @@ jobs:
       - name: Install Python 3.4 dependencies
         if: ${{ contains(matrix.python-version, '3.4') }}
         # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
-        run: pip install certifi==2021.10.8
+        run: pip install certifi==2021.10.8 typing-extensions<4
+
+      - name: Install Python 3.5 dependencies
+        if: ${{ contains(matrix.python-version, '3.5') }}
+        # typing-extensions dropped support for Python 3.5 in version 4
+        run: pip install typing-extensions<4
+
+      - name: Install Python 3.6 dependencies
+        if: ${{ contains(matrix.python-version, '3.6') }}
+        # typing-extensions dropped support for Python 3.6 in version 4.2
+        run: pip install typing-extensions<4.2
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,17 +242,17 @@ jobs:
       - name: Install Python 3.4 dependencies
         if: ${{ contains(matrix.python-version, '3.4') }}
         # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
-        run: pip install certifi==2021.10.8 typing-extensions<4
+        run: pip install certifi==2021.10.8 "typing-extensions<4"
 
       - name: Install Python 3.5 dependencies
         if: ${{ contains(matrix.python-version, '3.5') }}
         # typing-extensions dropped support for Python 3.5 in version 4
-        run: pip install typing-extensions<4
+        run: pip install "typing-extensions<4"
 
       - name: Install Python 3.6 dependencies
         if: ${{ contains(matrix.python-version, '3.6') }}
         # typing-extensions dropped support for Python 3.6 in version 4.2
-        run: pip install typing-extensions<4.2
+        run: pip install "typing-extensions<4.2"
 
       - name: Run tests
         run: python setup.py test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install Python 3.4 dependencies
         if: ${{ contains(matrix.python-version, '3.4') }}
         # certifi uses the 'typing' from Python 3.5 module starting in 2022.5.18
-        run: pip install certifi==2021.10.8
+        run: pip install certifi==2021.10.8 typing-extensions==3.10.0.1
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ tests_require = [
     'unittest2',
     'mock<=3.0.5; python_version < "3.3"',
     'enum34; python_version < "3.4"',
-    'typing-extensions<4; python_version < "3.6"',
-    'typing-extensions<4.2; python_version == "3.6"',
     'httpx; python_version >= "3.6"',
     'aiocontextvars; python_version == "3.6"'
 ]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ tests_require = [
     'unittest2',
     'mock<=3.0.5; python_version < "3.3"',
     'enum34; python_version < "3.4"',
+    'typing-extensions<4; python_version < "3.6"',
+    'typing-extensions<4.2; python_version == "3.6"',
     'httpx; python_version >= "3.6"',
     'aiocontextvars; python_version == "3.6"'
 ]


### PR DESCRIPTION
## Description of the change

certifi is a package that helps validate SSL root certificates that we depend on. In the latest release it started using Python 3 syntax. Since we have always been using the latest version, our Python 2 CI tests started failing after the last release of certifi.

This PR pip installs `certifi==2021.10.8` if our CI test matrix is testing on Python 2.7. This is not an ideal solution seeing that we will not be using up to date root certificates in our tests. However, that may be a compromise we are willing to make.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None ([see our latest failed action run](https://github.com/rollbar/pyrollbar/actions/runs/2377301005))

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
