### PR TITLE
Fix walk_trace_chain: change container for seen_exceptions

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -791,7 +791,7 @@ def _report_exc_info(exc_info, request, extra_data, payload_data, level=None):
 def _walk_trace_chain(cls, exc, trace):
     trace_chain = [_trace_data(cls, exc, trace)]
 
-    seen_exceptions = {exc}
+    seen_exceptions = [exc]
 
     while True:
         exc = getattr(exc, '__cause__', None) or getattr(exc, '__context__', None)
@@ -800,7 +800,7 @@ def _walk_trace_chain(cls, exc, trace):
         trace_chain.append(_trace_data(type(exc), exc, getattr(exc, '__traceback__', None)))
         if exc in seen_exceptions:
             break
-        seen_exceptions.add(exc)
+        seen_exceptions.append(exc)
 
     return trace_chain
 


### PR DESCRIPTION
## Description of the change

What if, for some reason, the exception is not hashable?

I ran into this problem using the library https://github.com/ecederstrand/exchangelib
Here's my pr https://github.com/ecederstrand/exchangelib/pull/1097

I don't know why the author decided to do that. Asked the author, haven't received an answer yet. Anyway, it seems to me that it's worth providing for such a possibility.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
