### PR TITLE
Replace `httpx.post` `data` kwarg with `content`

### DIFF
--- a/rollbar/lib/_async.py
+++ b/rollbar/lib/_async.py
@@ -138,7 +138,7 @@ async def _post_api_httpx(path, payload_str, access_token=None):
     ) as client:
         resp = await client.post(
             url,
-            data=payload_str,
+            content=payload_str,
             headers=headers,
             timeout=rollbar.SETTINGS.get('timeout', DEFAULT_TIMEOUT),
         )


### PR DESCRIPTION
## Description of the change

As described in https://github.com/encode/httpx/blame/08a557e3e2b9220b90ee21238e316206ffa65d36/docs/compatibility.md?plain=1#L70-L90 the `data` parameter in `httpx.post` was intended to provide compatibility from `requests`, but as it does not provide anymore for this end, it issues a warning

`DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.`

when using `pyrollbar` is used with `asyncio`

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [X] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
