### PR TITLE
Replace FastAPI pure str comparison with SemVer comparison

### DIFF
--- a/rollbar/contrib/fastapi/utils.py
+++ b/rollbar/contrib/fastapi/utils.py
@@ -22,36 +22,30 @@ class FastAPIVersionError(Exception):
 
 
 def is_current_version_higher_or_equal(current_version, min_version):
-    if current_version == min_version:
-        return True
+    """
+    Compare two version strings and return True if the current version is higher or equal to the minimum version.
 
-    for current_as_string, min_as_string in zip(
-        current_version.split('.'),
-        min_version.split('.'),
-    ):
-        if current_as_string == min_as_string:
-            continue
+    Note: This function only compares the release segment of the version string.
+    """
+    def parse_version(version):
+        """Parse the release segment of a version string into a list of strings."""
+        parsed = ['']
+        current_segment = 0
+        for c in version:
+            if c.isdigit():
+                parsed[current_segment] += c
+            elif c == '.':
+                current_segment += 1
+                parsed.append('')
+            else:
+                break
+        if parsed[-1] == '':
+            parsed.pop()
+        return parsed
 
-        try:
-            current_as_int = int(current_as_string)
-        except ValueError:
-            current_as_int = None
-
-        try:
-            min_as_int = int(min_as_string)
-        except ValueError:
-            min_as_int = None
-
-        if current_as_int is None or min_as_int is None:
-            # If one of the parts fails the int conversion, compare as string
-            return current_as_string > min_as_string
-        else:
-            if current_as_int == min_as_int:
-                continue
-            return current_as_int > min_as_int
-
-    # Somehow the comparison didn't properly finish - defaulting to False
-    return False
+    current = tuple(map(int, parse_version(current_version)))
+    minimum = tuple(map(int, parse_version(min_version)))
+    return current >= minimum
 
 
 class fastapi_min_version:

--- a/rollbar/test/fastapi_tests/test_utils.py
+++ b/rollbar/test/fastapi_tests/test_utils.py
@@ -121,3 +121,33 @@ class UtilsBareRoutingTest(BaseTest):
         app.include_router(router)
 
         self.assertFalse(has_bare_routing(app))
+
+
+class UtilsVersionCompareTest(BaseTest):
+    def test_is_current_version_higher_or_equal(self):
+        # Copied from https://semver.org/#spec-item-11
+        versions = [
+            '1.0.0-alpha',
+            '1.0.0-alpha.1',
+            '1.0.0-alpha.beta',
+            '1.0.0-beta',
+            '1.0.0-beta.2',
+            '1.0.0-beta.11',
+            '1.0.0-rc.1',
+            '1.0.0',
+            '1.1.1',
+            '1.100.0-beta2',
+            '1.100.0-beta3',
+        ]
+
+        from rollbar.contrib.fastapi.utils import is_current_version_higher_or_equal
+
+        previous_version = None
+        for version in versions:
+            print(f'{version} >= {previous_version}')
+            if previous_version is None:
+                previous_version = version
+                continue
+            with self.subTest(f'{version} >= {previous_version}'):
+                self.assertTrue(is_current_version_higher_or_equal(version, previous_version))
+            previous_version = version

--- a/rollbar/test/fastapi_tests/test_utils.py
+++ b/rollbar/test/fastapi_tests/test_utils.py
@@ -122,7 +122,9 @@ class UtilsBareRoutingTest(BaseTest):
 
         self.assertFalse(has_bare_routing(app))
 
-
+@unittest.skipUnless(
+    FASTAPI_INSTALLED and ALLOWED_PYTHON_VERSION, 'FastAPI requires Python3.6+'
+)
 class UtilsVersionCompareTest(BaseTest):
     def test_is_current_version_higher_or_equal(self):
         # Copied from https://semver.org/#spec-item-11


### PR DESCRIPTION
## Description of the change

This is a solution proposal for #432: the current FastAPI version comparison fails for version `0.100.0-beta2` because the lexicographic comparison of the string value fails because `"1"` is less than `"4"` even if the numerical value `100` is higher than `41`.

Before:
```python
ipdb> self.min_version
'0.41.0'
ipdb> fastapi.__version__
'0.100.0-beta2'
ipdb> fastapi.__version__ < self.min_version  # due to lexicographic comparison, not proper SemVer comparison
True
```

After:
```python
ipdb> self.min_version
'0.41.0'
ipdb> fastapi.__version__
'0.100.0-beta2'
ipdb> not is_current_version_higher_or_equal(fastapi.__version__, self.min_version)
False
```


## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #432

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [X] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
