### PR TITLE
Revert "Move user provided extra data under custom (#431)"

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -839,59 +839,6 @@ def _trace_data(cls, exc, trace):
     return trace_data
 
 
-def _process_extra_data(data, extra_data):
-    """
-    If `extra_data` contains `args` or select keys in `record` then that's
-    something pyrollbar generated with the logger, which is to be put in
-    data.body.message. Otherwise, `extra_data` was passed through by a user,
-    which is to be put in custom.
-    """
-    custom = {}
-    body_message = {}
-
-    record_logger_keys = [
-        'created',
-        'funcName',
-        'lineno',
-        'module',
-        'name',
-        'pathname',
-        'process',
-        'processName',
-        'relativeCreated',
-        'thread',
-        'threadName',
-    ]
-
-    for k, v in extra_data.items():
-        if k == 'args':
-            body_message['args'] = v
-
-        elif k == 'record':
-            record_full = v
-            record_custom = {}
-            record_body_message = {}
-
-            if isinstance(record_full, dict):
-                for kk, vv in record_full.items():
-                    if kk in record_logger_keys:
-                        record_body_message[kk] = vv
-                    else:
-                        record_custom[kk] = vv
-
-            if record_custom:
-                custom['record'] = record_custom
-            if record_body_message:
-                body_message['record'] = record_body_message
-
-        else:
-            custom[k] = v
-
-    if custom:
-        data['custom'] = custom
-    data['body']['message'].update(body_message)
-
-
 def _report_message(message, level, request, extra_data, payload_data):
     """
     Called by report_message() wrapper
@@ -919,7 +866,7 @@ def _report_message(message, level, request, extra_data, payload_data):
 
     if extra_data:
         extra_data = extra_data
-        _process_extra_data(data, extra_data)
+        data['body']['message'].update(extra_data)
 
     request = _get_actual_request(request)
     _add_request_data(data, request)

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -2,6 +2,7 @@
 Tests for the RollbarHandler logging handler
 """
 import copy
+import json
 import logging
 import sys
 
@@ -50,19 +51,6 @@ class LogHandlerTest(BaseTest):
         self.assertEqual(payload['data']['body']['message']['body'], "Hello 1 world")
         self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
         self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
-
-    @mock.patch('rollbar.send_payload')
-    def test_logger_related_fields_are_in_body_message(self, send_payload):
-        logger = self._create_logger()
-        logger.warning("Hello %d %s", 1, 'world')
-
-        payload = send_payload.call_args[0][0]
-
-        self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
-        self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
-        self.assertEqual(payload['data']['body']['message']['record']['module'], 'test_loghandler')
-        self.assertEqual(payload['data']['body']['message']['record']['funcName'],
-                         'test_logger_related_fields_are_in_body_message')
 
     @mock.patch('rollbar.send_payload')
     def test_string_or_int_level(self, send_payload):

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -892,18 +892,6 @@ class RollbarTest(BaseTest):
         self.assertEqual(payload['data']['body']['message']['body'], 'foo')
 
     @mock.patch('rollbar.send_payload')
-    def test_user_provided_extra_data_ends_up_in_custom(self, send_payload):
-        rollbar.report_message('foo', extra_data={'id': 123, 'name': 'John'})
-
-        payload = send_payload.call_args[0][0]
-
-        self.assertIn('custom', payload['data'])
-        self.assertIn('id', payload['data']['custom'])
-        self.assertIn('name', payload['data']['custom'])
-        self.assertEqual(payload['data']['custom']['id'], 123)
-        self.assertEqual(payload['data']['custom']['name'], 'John')
-
-    @mock.patch('rollbar.send_payload')
     def test_uuid(self, send_payload):
         uuid = rollbar.report_message('foo')
 


### PR DESCRIPTION
## Description of the change

This PR reverts the changes in commit e3e159533dfec07ea0d7c2ec678267552db96bfb, except for the version tag. We decided we won't need these changes. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)
- Fix [SC-129187]

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
