### PR TITLE
Removed support for Python 2 for upcoming v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
         framework:
-          - FLASK_VERSION=0.12.5 Werkzeug\>=0.7,\<1.0
           - FLASK_VERSION=1.1.4
           - FLASK_VERSION=2.2.3
           - DJANGO_VERSION=1.11.29
@@ -76,7 +75,12 @@ jobs:
       - name: Install Python 3.6 dependencies
         if: ${{ contains(matrix.python-version, '3.6') }}
         # typing-extensions dropped support for Python 3.6 in version 4.2
-        run: pip install "typing-extensions<4.2" requests==2.27.0 blinker==1.5
+        run: pip install "typing-extensions<4.2" requests==2.27.0 blinker==1.5 immutables==0.19
+
+      - name: Install Python 3.7 dependencies
+        if: ${{ contains(matrix.python-version, '3.7') }}
+        # immutables dropped support for Python<3.8 in version 0.20
+        run: pip install immutables==0.19
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
         framework:
           - FLASK_VERSION=0.12.5 Werkzeug\>=0.7,\<1.0
           - FLASK_VERSION=1.1.4
@@ -35,8 +35,6 @@ jobs:
           # Test frameworks on the python versions they support, according to pypi registry
           # Flask
           - framework: FLASK_VERSION=2.2.3
-            python-version: 3.5
-          - framework: FLASK_VERSION=2.2.3
             python-version: 3.6
 
           # Django
@@ -48,10 +46,6 @@ jobs:
             python-version: '3.10'
           - framework: DJANGO_VERSION=1.11.29
             python-version: 3.11
-          - framework: DJANGO_VERSION=3.2.18
-            python-version: 3.5
-          - framework: DJANGO_VERSION=4.0.10
-            python-version: 3.5
           - framework: DJANGO_VERSION=4.0.10
             python-version: 3.6
           - framework: DJANGO_VERSION=4.0.10
@@ -66,27 +60,8 @@ jobs:
           # Twisted
           - framework: TWISTED_VERSION=20.3.0
             python-version: 3.11
-          - framework: TWISTED_VERSION=21.7.0
-            python-version: 3.5
-          - framework: TWISTED_VERSION=22.10.0
-            python-version: 3.5
           - framework: TWISTED_VERSION=22.10.0
             python-version: 3.6
-
-
-          # Starlette
-          - framework: STARLETTE_VERSION=0.12.13 httpx==0.18.1 python-multipart==0.0.5
-            python-version: 3.5
-          - framework: STARLETTE_VERSION=0.14.2 httpx==0.18.1 python-multipart==0.0.5
-            python-version: 3.5
-
-          # Fastapi
-          - framework: FASTAPI_VERSION=0.40.0 httpx==0.18.1 python-multipart==0.0.5
-            python-version: 3.5
-          - framework: FASTAPI_VERSION=0.50.0 httpx==0.18.1 python-multipart==0.0.5
-            python-version: 3.5
-          - framework: FASTAPI_VERSION=0.63.0 httpx==0.18.1 python-multipart==0.0.5
-            python-version: 3.5
 
     steps:
       - uses: actions/checkout@v2
@@ -98,15 +73,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python 3.5 dependencies
-        if: ${{ contains(matrix.python-version, '3.5') }}
-        # typing-extensions dropped support for Python 3.5 in version 4
-        run: pip install six==1.16.0 "typing-extensions<4" requests==2.24.0 blinker==1.5 WebOb==1.8.7
-
       - name: Install Python 3.6 dependencies
         if: ${{ contains(matrix.python-version, '3.6') }}
         # typing-extensions dropped support for Python 3.6 in version 4.2
-        run: pip install six==1.16.0 "typing-extensions<4.2" requests==2.27.0 blinker==1.5
+        run: pip install "typing-extensions<4.2" requests==2.27.0 blinker==1.5
 
       - name: Set the framework
         run: echo ${{ matrix.framework }} >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -20,17 +20,29 @@ Python notifier for reporting exceptions, errors, and log messages to [Rollbar](
 - **Advanced search:** Filter items by many different properties. <a href="https://docs.rollbar.com/docs/search-items">Learn more about search</a>.
 - **Customizable notifications:** Rollbar supports several messaging and incident management tools where your team can get notified about errors and important events by real-time alerts. <a href="https://docs.rollbar.com/docs/notifications">Learn more about Rollbar notifications</a>.
 
+## Versions Supported
 
-# Setup Instructions
+| PyRollbar Version | Python Version Compatibility                  | Support Level       |
+|-------------------|-----------------------------------------------|---------------------|
+| 0.17.0            | 3.6, 3.7. 3.8, 3.9, 3.10, 3.11                | Full                |
+| 0.16.3            | 2.7, 3.4, 3.5, 3.6, 3.7. 3.8, 3.9, 3.10, 3.11 | Security Fixes Only |
+
+#### Support Level Definitions
+
+**Full** - We will support new features of the library and test against all supported versions.
+
+**Security Fixes Only** - We will only provide critical security fixes for the library.
+
+## Setup Instructions
 
 1. [Sign up for a Rollbar account](https://rollbar.com/signup)
 2. Follow the [Quick Start](https://docs.rollbar.com/docs/python#section-quick-start) instructions in our [Python SDK docs](https://docs.rollbar.com/docs/python) to install pyrollbar and configure it for your platform.
 
-# Usage and Reference
+## Usage and Reference
 
 For complete usage instructions and configuration reference, see our [Python SDK docs](https://docs.rollbar.com/docs/python).
 
-# Release History & Changelog
+## Release History & Changelog
 
 See our [Releases](https://github.com/rollbar/pyrollbar/releases) page for a list of all releases, including changes.
 

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -81,7 +81,7 @@ except ImportError:
 
 try:
     from google.appengine.api.urlfetch import fetch as AppEngineFetch
-except ImportError:
+except (ImportError, KeyError):
     AppEngineFetch = None
 
 try:

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -24,7 +24,7 @@ import requests
 from rollbar.lib import events, filters, dict_merge, transport, defaultJSONEncode
 
 
-__version__ = '0.16.4beta2'
+__version__ = '1.0.0b0'
 __log_name__ = 'rollbar'
 log = logging.getLogger(__log_name__)
 

--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -86,7 +86,6 @@ import rollbar
 from django.core.exceptions import MiddlewareNotUsed
 from django.conf import settings
 from django.http import Http404
-from six import reraise
 
 try:
     from django.urls import resolve
@@ -311,7 +310,9 @@ class RollbarNotifierMiddlewareOnly404(MiddlewareMixin):
         try:
             if hasattr(request, '_rollbar_notifier_original_http404_exc_info'):
                 exc_type, exc_value, exc_traceback = request._rollbar_notifier_original_http404_exc_info
-                reraise(exc_type, exc_value, exc_traceback)
+                if exc_value is None:
+                    exc_value = Http404()
+                raise exc_value.with_traceback(exc_traceback)
             else:
                 raise Http404()
         except Exception as exc:

--- a/rollbar/contrib/pyramid/__init__.py
+++ b/rollbar/contrib/pyramid/__init__.py
@@ -138,7 +138,7 @@ def includeme(config):
     environment = kw.pop('environment', 'production')
 
     if kw.get('scrub_fields'):
-        kw['scrub_fields'] = set([str.strip(x) for x in kw.get('scrub_fields').split('\n') if x])
+        kw['scrub_fields'] = {str.strip(x) for x in kw.get('scrub_fields').split('\n') if x}
 
     if kw.get('exception_level_filters'):
         r = DottedNameResolver()

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -4,86 +4,21 @@ import copy
 import os
 import sys
 from array import array
-import json
 
-try:
-    # Python 3
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2.7
-    from collections import Mapping
+from collections.abc import Mapping
 
-import six
-from six.moves import urllib
-
-iteritems = six.iteritems
-reprlib = six.moves.reprlib
-
-binary_type = six.binary_type
-integer_types = six.integer_types
-number_types = integer_types + (float, )
-string_types = six.string_types
+binary_type = bytes
+integer_types = int
+number_types = (float, int)
+string_types = str
 sequence_types = (Mapping, list, tuple, set, frozenset, array, collections.deque)
 
-urlparse = urllib.parse.urlparse
-urlsplit = urllib.parse.urlsplit
-urlunparse = urllib.parse.urlunparse
-urlunsplit = urllib.parse.urlunsplit
-parse_qs = urllib.parse.parse_qs
-urlencode = urllib.parse.urlencode
-urljoin = urllib.parse.urljoin
-quote = urllib.parse.quote
 
-
-_version = sys.version_info
-
-
-def python_major_version():
-    return _version[0]
-
-
-if python_major_version() < 3:
-    def text(val):
-        if isinstance(val, (str, unicode)):
-            return val
-
-        conversion_options = [unicode, lambda x: unicode(x, encoding='utf8')]
-        for option in conversion_options:
-            try:
-                return option(val)
-            except UnicodeDecodeError:
-                pass
-
-        return repr(val)
-
-    _map = map
-
-    def map(*args):
-        return _map(*args)
-
-    def force_lower(val):
+def force_lower(val):
+    try:
+        return val.lower()
+    except:
         return str(val).lower()
-
-else:
-    def text(val):
-        return str(val)
-
-    _map = map
-
-    def map(*args):
-        return list(_map(*args))
-
-    def force_lower(val):
-        try:
-            return val.lower()
-        except:
-            return str(val).lower()
-
-
-def do_for_python_version(two_fn, three_fn, *args, **kw):
-    if python_major_version() < 3:
-        return two_fn(*args, **kw)
-    return three_fn(*args, **kw)
 
 
 def prefix_match(key, prefixes):
@@ -126,7 +61,7 @@ def key_match(key1, key2):
 
 def reverse_list_of_lists(l, apply_each_fn=None):
     apply_each_fn = apply_each_fn or (lambda x: x)
-    return map(lambda x: list(reversed(map(apply_each_fn, x))), l or [])
+    return [reversed([apply_each_fn(x) for x in inner]) for inner in l or []]
 
 
 def build_key_matcher(prefixes_or_suffixes, type='prefix', case_sensitive=False):
@@ -183,9 +118,9 @@ def dict_merge(a, b, silence_errors=False):
         else:
             try:
                 result[k] = copy.deepcopy(v)
-            except:
+            except Exception as e:
                 if not silence_errors:
-                    raise six.reraise(*sys.exc_info())
+                    raise e
 
                 result[k] = '<Uncopyable obj:(%s)>' % (v,)
 
@@ -193,7 +128,7 @@ def dict_merge(a, b, silence_errors=False):
 
 
 def circular_reference_label(data, ref_key=None):
-    ref = '.'.join(map(text, ref_key))
+    ref = '.'.join([str(x) for x in ref_key])
     return '<CircularReference type:(%s) ref:(%s)>' % (type(data).__name__, ref)
 
 

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -1,8 +1,6 @@
 import base64
 import collections
 import copy
-import os
-import sys
 from array import array
 
 from collections.abc import Mapping
@@ -26,8 +24,10 @@ def prefix_match(key, prefixes):
         return False
 
     for prefix in prefixes:
-        common_prefix = os.path.commonprefix((prefix, key))
-        if common_prefix == prefix:
+        if len(prefix) > len(key):
+            continue
+
+        if prefix == key[:len(prefix)]:
             return True
 
     return False
@@ -45,18 +45,17 @@ def key_in(key, keys):
 
 
 def key_match(key1, key2):
-    key1_len = len(key1)
-    key2_len = len(key2)
-    if key1_len != key2_len:
+    if len(key1) != len(key2):
         return False
 
-    z_key = zip(key1, key2)
-    num_matches = 0
-    for p1, p2 in z_key:
-        if '*' in (p1, p2) or p1 == p2:
-            num_matches += 1
+    for p1, p2 in zip(key1, key2):
+        if '*' == p1 or '*' == p2:
+            continue
+        if p1 == p2:
+            continue
+        return False
 
-    return num_matches == key1_len
+    return True
 
 
 def reverse_list_of_lists(l, apply_each_fn=None):

--- a/rollbar/lib/_async.py
+++ b/rollbar/lib/_async.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import sys
 from unittest import mock
+from urllib.parse import urljoin
 
 try:
     import httpx
@@ -12,7 +13,7 @@ except ImportError:
 
 import rollbar
 from rollbar import DEFAULT_TIMEOUT
-from rollbar.lib import transport, urljoin
+from rollbar.lib import transport
 
 log = logging.getLogger(__name__)
 

--- a/rollbar/lib/transform.py
+++ b/rollbar/lib/transform.py
@@ -23,10 +23,7 @@ class Transform(object):
     def transform_number(self, o, key=None):
         return self.default(o, key=key)
 
-    def transform_py2_str(self, o, key=None):
-        return self.default(o, key=key)
-
-    def transform_py3_bytes(self, o, key=None):
+    def transform_bytes(self, o, key=None):
         return self.default(o, key=key)
 
     def transform_unicode(self, o, key=None):

--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -1,12 +1,6 @@
-try:
-    # Python 3
-    from collections.abc import Iterable
-except ImportError:
-    # Python 2.7
-    from collections import Iterable
+from collections.abc import Iterable
 
 from rollbar.lib import (
-    python_major_version,
     binary_type,
     string_types,
     integer_types,
@@ -56,21 +50,11 @@ def _transform(obj, transform, key=None):
 
         return val
 
-    if python_major_version() < 3:
-
-        def string_handler(s, key=None):
-            if isinstance(s, str):
-                return do_transform("py2_str", s, key=key)
-            elif isinstance(s, unicode):
-                return do_transform("unicode", s, key=key)
-
-    else:
-
-        def string_handler(s, key=None):
-            if isinstance(s, bytes):
-                return do_transform("py3_bytes", s, key=key)
-            elif isinstance(s, str):
-                return do_transform("unicode", s, key=key)
+    def string_handler(s, key=None):
+        if isinstance(s, bytes):
+            return do_transform("bytes", s, key=key)
+        elif isinstance(s, str):
+            return do_transform("unicode", s, key=key)
 
     def default_handler(o, key=None):
         if isinstance(o, bool):

--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -3,10 +3,8 @@ from collections.abc import Iterable
 from rollbar.lib import (
     binary_type,
     string_types,
-    integer_types,
     number_types,
     traverse,
-    type_info,
 )
 # NOTE: Don't remove this import, it would cause a breaking change to the library's API.
 # The `Transform` class was moved out of this file to prevent a cyclical dependency issue.

--- a/rollbar/lib/transforms/batched.py
+++ b/rollbar/lib/transforms/batched.py
@@ -1,6 +1,5 @@
 from rollbar.lib.transform import Transform
 from rollbar.lib import (
-    python_major_version,
     number_types,
     type_info,
 )
@@ -13,21 +12,11 @@ def do_transform(transform, type_name, val, key=None, **kw):
     return val
 
 
-if python_major_version() < 3:
-
-    def string_handler(transform, s, key=None):
-        if isinstance(s, str):
-            return do_transform(transform, "py2_str", s, key=key)
-        elif isinstance(s, unicode):
-            return do_transform(transform, "unicode", s, key=key)
-
-else:
-
-    def string_handler(transform, s, key=None):
-        if isinstance(s, bytes):
-            return do_transform(transform, "py3_bytes", s, key=key)
-        elif isinstance(s, str):
-            return do_transform(transform, "unicode", s, key=key)
+def string_handler(transform, s, key=None):
+    if isinstance(s, bytes):
+        return do_transform(transform, "bytes", s, key=key)
+    elif isinstance(s, str):
+        return do_transform(transform, "unicode", s, key=key)
 
 
 def default_handler(transform, o, key=None):

--- a/rollbar/lib/transforms/scrub.py
+++ b/rollbar/lib/transforms/scrub.py
@@ -5,13 +5,17 @@ from rollbar.lib.transform import Transform
 
 
 class ScrubTransform(Transform):
+    suffix_matcher = None
     def __init__(self, suffixes=None, redact_char='*', randomize_len=True):
         super(ScrubTransform, self).__init__()
-        self.suffix_matcher = build_key_matcher(suffixes, type='suffix')
+        if suffixes is not None and len(suffixes) > 0:
+            self.suffix_matcher = build_key_matcher(suffixes, type='suffix')
         self.redact_char = redact_char
         self.randomize_len = randomize_len
 
     def in_scrub_fields(self, key):
+        if self.suffix_matcher is None:
+            return False
         return self.suffix_matcher(key)
 
     def redact(self, val):

--- a/rollbar/lib/transforms/scrub.py
+++ b/rollbar/lib/transforms/scrub.py
@@ -1,6 +1,6 @@
 import random
 
-from rollbar.lib import build_key_matcher, text
+from rollbar.lib import build_key_matcher
 from rollbar.lib.transform import Transform
 
 
@@ -21,7 +21,7 @@ class ScrubTransform(Transform):
             try:
                 _len = len(val)
             except:
-                _len = len(text(val))
+                _len = len(str(val))
 
         return self.redact_char * _len
 

--- a/rollbar/lib/transforms/scruburl.py
+++ b/rollbar/lib/transforms/scruburl.py
@@ -1,6 +1,7 @@
 import re
+from urllib.parse import urlsplit, urlencode, urlunsplit, parse_qs
 
-from rollbar.lib import iteritems, map, urlsplit, urlencode, urlunsplit, parse_qs, string_types, binary_type
+from rollbar.lib import string_types, binary_type
 from rollbar.lib.transforms.scrub import ScrubTransform
 
 
@@ -21,7 +22,7 @@ class ScrubUrlTransform(ScrubTransform):
                                                 randomize_len=randomize_len)
         self.scrub_username = scrub_username
         self.scrub_password = scrub_password
-        self.params_to_scrub = set(map(lambda x: x.lower(), params_to_scrub))
+        self.params_to_scrub = {x.lower() for x in params_to_scrub or []}
 
     def in_scrub_fields(self, key):
         # Returning True here because we want to scrub URLs out of
@@ -51,9 +52,9 @@ class ScrubUrlTransform(ScrubTransform):
         if not netloc:
             return url_string
 
-        for qs_param, vals in iteritems(qs_params):
+        for qs_param, vals in qs_params.items():
             if qs_param.lower() in self.params_to_scrub:
-                vals2 = map(_redact, vals)
+                vals2 = [_redact(x) for x in vals]
                 qs_params[qs_param] = vals2
 
         scrubbed_qs = urlencode(qs_params, doseq=True)

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -1,17 +1,13 @@
 from array import array
 import collections
 import itertools
+import reprlib
 
-try:
-    # Python 3
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2.7
-    from collections import Mapping
+from collections.abc import Mapping
 
 from rollbar.lib import (
-    integer_types, iteritems, key_in, number_types, reprlib, sequence_types,
-    string_types, text)
+    integer_types, key_in, number_types, sequence_types,
+    string_types)
 from rollbar.lib.transform import Transform
 
 
@@ -36,11 +32,11 @@ class ShortenerTransform(Transform):
         self.keys = keys
         self._repr = reprlib.Repr()
 
-        for name, size in iteritems(sizes):
+        for name, size in sizes.items():
             setattr(self._repr, name, size)
 
     def _get_max_size(self, obj):
-        for name, _type in iteritems(_type_name_mapping):
+        for name, _type in _type_name_mapping.items():
             # Special case for dicts since we are using collections.abc.Mapping
             # to provide better type checking for dict-like objects
             if name == 'mapping':
@@ -66,7 +62,7 @@ class ShortenerTransform(Transform):
         return {k: obj[k] for k in itertools.islice(obj.keys(), max_keys)}
 
     def _shorten_basic(self, obj, max_len):
-        val = text(obj)
+        val = str(obj)
         if len(val) <= max_len:
             return obj
 
@@ -77,7 +73,7 @@ class ShortenerTransform(Transform):
             return None
 
         if self.safe_repr:
-            obj = text(obj)
+            obj = str(obj)
 
         return self._repr.repr(obj)
 

--- a/rollbar/lib/traverse.py
+++ b/rollbar/lib/traverse.py
@@ -1,7 +1,7 @@
 import logging
 
 
-from rollbar.lib import binary_type, iteritems, string_types, circular_reference_label
+from rollbar.lib import binary_type, string_types, circular_reference_label
 
 # NOTE: Don't remove this line of code as it would cause a breaking change
 # to the library's API. The items imported here were originally in this file
@@ -118,29 +118,27 @@ def traverse(
             return namedtuple_handler(
                 obj._make(
                     traverse(v, key=key + (k,), **kw)
-                    for k, v in iteritems(obj._asdict())
+                    for k, v in obj._asdict().items()
                 ),
                 key=key,
             )
         elif obj_type is LIST:
             return list_handler(
-                list(
-                    traverse(elem, key=key + (i,), **kw) for i, elem in enumerate(obj)
-                ),
+                [traverse(elem, key=key + (i,), **kw) for i, elem in enumerate(obj)],
                 key=key,
             )
         elif obj_type is SET:
             return set_handler(
-                set(traverse(elem, key=key + (i,), **kw) for i, elem in enumerate(obj)),
+                {traverse(elem, key=key + (i,), **kw) for i, elem in enumerate(obj)},
                 key=key,
             )
         elif obj_type is MAPPING:
             return mapping_handler(
-                dict((k, traverse(v, key=key + (k,), **kw)) for k, v in iteritems(obj)),
+                {k: traverse(v, key=key + (k,), **kw) for k, v in obj.items()},
                 key=key,
             )
         elif obj_type is DEFAULT:
-            for handler_type, handler in iteritems(custom_handlers):
+            for handler_type, handler in custom_handlers.items():
                 if isinstance(obj, handler_type):
                     return handler(obj, key=key)
     except:

--- a/rollbar/lib/type_info.py
+++ b/rollbar/lib/type_info.py
@@ -1,16 +1,7 @@
 from rollbar.lib import binary_type, string_types
 
 
-try:
-    # Python 3
-    from collections.abc import Mapping
-    from collections.abc import Sequence
-    from collections.abc import Set
-except ImportError:
-    # Python 2.7
-    from collections import Mapping
-    from collections import Sequence
-    from collections import Set
+from collections.abc import Mapping, Sequence, Set
 
 
 CIRCULAR = -1

--- a/rollbar/test/__init__.py
+++ b/rollbar/test/__init__.py
@@ -1,5 +1,4 @@
 import unittest
-import sys
 
 
 SNOWMAN = b'\xe2\x98\x83'
@@ -10,24 +9,7 @@ class BaseTest(unittest.TestCase):
     pass
 
 
-class SkipAsyncTestLoader(unittest.TestLoader):
-    """
-    Python 2 does not have the async keyword, so when tests are run under python 2.7 the loader
-    will fail with a syntaxerror. This loader class does the following:
-    - try to load as normal
-    - if loading fails because of a syntax error in python < 3.4, skip the file.
-    """
-    def _get_module_from_name(self, name):
-        try:
-            return super(SkipAsyncTestLoader, self)._get_module_from_name(name)
-        except SyntaxError as e:
-            if sys.version_info < (3, 5):
-                return None
-            else:
-                raise
-
-
 def discover():
-    loader = SkipAsyncTestLoader()
+    loader = unittest.TestLoader()
     suite = loader.discover(__name__)
     return suite

--- a/rollbar/test/asgi_tests/test_middleware.py
+++ b/rollbar/test/asgi_tests/test_middleware.py
@@ -2,10 +2,7 @@ import copy
 import importlib
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import unittest
 

--- a/rollbar/test/async_tests/test_async.py
+++ b/rollbar/test/async_tests/test_async.py
@@ -1,10 +1,7 @@
 import copy
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import unittest
 

--- a/rollbar/test/fastapi_tests/test_logger.py
+++ b/rollbar/test/fastapi_tests/test_logger.py
@@ -1,10 +1,7 @@
 import importlib
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 try:
     import fastapi

--- a/rollbar/test/fastapi_tests/test_middleware.py
+++ b/rollbar/test/fastapi_tests/test_middleware.py
@@ -2,10 +2,7 @@ import copy
 import importlib
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 try:
     import fastapi

--- a/rollbar/test/fastapi_tests/test_routing.py
+++ b/rollbar/test/fastapi_tests/test_routing.py
@@ -3,10 +3,7 @@ import importlib
 import json
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 try:
     import fastapi

--- a/rollbar/test/flask_tests/test_flask.py
+++ b/rollbar/test/flask_tests/test_flask.py
@@ -6,10 +6,7 @@ import json
 import sys
 import os
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import rollbar
 

--- a/rollbar/test/starlette_tests/test_logger.py
+++ b/rollbar/test/starlette_tests/test_logger.py
@@ -1,10 +1,7 @@
 import importlib
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 try:
     import starlette

--- a/rollbar/test/starlette_tests/test_middleware.py
+++ b/rollbar/test/starlette_tests/test_middleware.py
@@ -2,10 +2,7 @@ import copy
 import importlib
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 try:
     import starlette

--- a/rollbar/test/test_lib.py
+++ b/rollbar/test/test_lib.py
@@ -2,7 +2,6 @@ from rollbar.lib import dict_merge
 
 from rollbar.test import BaseTest
 
-import six
 
 class RollbarLibTest(BaseTest):
     def test_dict_merge_not_dict(self):
@@ -58,4 +57,4 @@ class RollbarLibTest(BaseTest):
         self.assertIn('b', result['a'])
         self.assertEqual(42, result['a']['b'])
         self.assertIn('y', result['a'])
-        six.assertRegex(self, result['a']['y'], r'Uncopyable obj')
+        self.assertRegex(result['a']['y'], r'Uncopyable obj')

--- a/rollbar/test/test_lib.py
+++ b/rollbar/test/test_lib.py
@@ -1,4 +1,4 @@
-from rollbar.lib import dict_merge
+from rollbar.lib import dict_merge, prefix_match
 
 from rollbar.test import BaseTest
 
@@ -10,6 +10,14 @@ class RollbarLibTest(BaseTest):
         result = dict_merge(a, b)
 
         self.assertEqual(99, result)
+
+    def test_prefix_match(self):
+        key = ['password', 'argspec', '0']
+        self.assertTrue(prefix_match(key, [['password']]))
+
+    def test_prefix_match(self):
+        key = ['environ', 'argspec', '0']
+        self.assertFalse(prefix_match(key, [['password']]))
 
     def test_dict_merge_dicts_independent(self):
         a = {'a': {'b': 42}}

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -5,10 +5,7 @@ import copy
 import logging
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import rollbar
 from rollbar.logger import RollbarHandler
@@ -93,25 +90,23 @@ class LogHandlerTest(BaseTest):
             logger.warning("Warning message", extra={"request": request})
             self.assertEqual(report_message_mock.call_args[1]["request"], request)
 
-        # Python 2.6 doesnt support extra param in logger.exception.
-        if not sys.version_info[:2] == (2, 6):
-            # if you call logger.exception outside of an exception
-            # handler, it shouldn't try to report exc_info, since it
-            # won't have any
-            with mock.patch("rollbar.report_exc_info") as report_exc_info:
-                with mock.patch("rollbar.report_message") as report_message_mock:
-                    logger.exception("Exception message", extra={"request": request})
-                    report_exc_info.assert_not_called()
-                    self.assertEqual(report_message_mock.call_args[1]["request"], request)
+        # if you call logger.exception outside of an exception
+        # handler, it shouldn't try to report exc_info, since it
+        # won't have any
+        with mock.patch("rollbar.report_exc_info") as report_exc_info:
+            with mock.patch("rollbar.report_message") as report_message_mock:
+                logger.exception("Exception message", extra={"request": request})
+                report_exc_info.assert_not_called()
+                self.assertEqual(report_message_mock.call_args[1]["request"], request)
 
-            with mock.patch("rollbar.report_exc_info") as report_exc_info:
-                with mock.patch("rollbar.report_message") as report_message_mock:
-                    try:
-                        raise Exception()
-                    except:
-                        logger.exception("Exception message", extra={"request": request})
-                        self.assertEqual(report_exc_info.call_args[1]["request"], request)
-                        report_message_mock.assert_not_called()
+        with mock.patch("rollbar.report_exc_info") as report_exc_info:
+            with mock.patch("rollbar.report_message") as report_message_mock:
+                try:
+                    raise Exception()
+                except:
+                    logger.exception("Exception message", extra={"request": request})
+                    self.assertEqual(report_exc_info.call_args[1]["request"], request)
+                    report_message_mock.assert_not_called()
 
     @mock.patch('rollbar.send_payload')
     def test_nested_exception_trace_chain(self, send_payload):

--- a/rollbar/test/test_pyramid.py
+++ b/rollbar/test/test_pyramid.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from rollbar.test import BaseTest
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -11,16 +11,13 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+
+from unittest import mock
 
 import unittest
-import six
 
 import rollbar
-from rollbar.lib import python_major_version, string_types
+from rollbar.lib import string_types
 
 from rollbar.test import BaseTest
 
@@ -464,18 +461,8 @@ class RollbarTest(BaseTest):
         app = FastAPI()
         app.add_middleware(ReporterMiddleware)
 
-        # Inject annotations and decorate endpoint dynamically
-        # to avoid SyntaxError for older Python
-        #
-        # This is the code we'd use if we had not loaded the test file on Python 2.
-        #
-        # @app.get('/{param}')
-        # def root(param, fastapi_request: Request):
-        #     current_request = rollbar.get_request()
-        #
-        #     self.assertEqual(current_request, fastapi_request)
-
-        def root(param, fastapi_request):
+        @app.get('/{param}')
+        def root(param, fastapi_request: Request):
             current_request = rollbar.get_request()
 
             self.assertEqual(current_request, fastapi_request)
@@ -501,18 +488,8 @@ class RollbarTest(BaseTest):
         app = FastAPI()
         app.add_middleware(ReporterMiddleware)
 
-        # Inject annotations and decorate endpoint dynamically
-        # to avoid SyntaxError for older Python
-        #
-        # This is the code we'd use if we had not loaded the test file on Python 2.
-        #
-        # @app.get('/{param}')
-        # def root(fastapi_request: Request):
-        #     current_request = rollbar.get_request()
-        #
-        #     self.assertEqual(current_request, fastapi_request)
-
-        def root(param, fastapi_request):
+        @app.get('/{param}')
+        def root(fastapi_request: Request):
             current_request = rollbar.get_request()
 
             self.assertEqual(current_request, fastapi_request)
@@ -542,18 +519,8 @@ class RollbarTest(BaseTest):
         app = FastAPI()
         rollbar_add_to(app)
 
-        # Inject annotations and decorate endpoint dynamically
-        # to avoid SyntaxError for older Python
-        #
-        # This is the code we'd use if we had not loaded the test file on Python 2.
-        #
-        # @app.get('/{param}')
-        # def root(fastapi_request: Request):
-        #     current_request = rollbar.get_request()
-        #
-        #     self.assertEqual(current_request, fastapi_request)
-
-        def root(param, fastapi_request):
+        @app.get('/{param}')
+        def root(fastapi_request: Request):
             current_request = rollbar.get_request()
 
             self.assertEqual(current_request, fastapi_request)
@@ -1202,7 +1169,7 @@ class RollbarTest(BaseTest):
         varargs = payload['data']['body']['trace']['frames'][-1]['varargspec']
 
         self.assertEqual(1, len(payload['data']['body']['trace']['frames'][-1]['locals'][varargs]))
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals'][varargs][0], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals'][varargs][0], r'\*+')
 
     @mock.patch('rollbar.send_payload')
     def test_args_lambda_with_star_args_and_args(self, send_payload):
@@ -1229,8 +1196,8 @@ class RollbarTest(BaseTest):
         self.assertEqual('arg1-value', payload['data']['body']['trace']['frames'][-1]['locals']['arg1'])
 
         self.assertEqual(2, len(payload['data']['body']['trace']['frames'][-1]['locals'][varargs]))
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals'][varargs][0], r'\*+')
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals'][varargs][1], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals'][varargs][0], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals'][varargs][1], r'\*+')
 
     @mock.patch('rollbar.send_payload')
     def test_args_lambda_with_kwargs(self, send_payload):
@@ -1395,8 +1362,8 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(2, len(payload['data']['body']['trace']['frames'][-1]['argspec']))
         self.assertEqual('password', payload['data']['body']['trace']['frames'][-1]['argspec'][0])
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals']['password'], r'\*+')
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals']['headers']['Authorization'], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['password'], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['headers']['Authorization'], r'\*+')
         self.assertEqual('clear', payload['data']['body']['trace']['frames'][-1]['argspec'][1])
         self.assertEqual('text', payload['data']['body']['trace']['frames'][-1]['locals']['clear'])
 
@@ -1450,7 +1417,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(2, len(payload['data']['body']['trace']['frames'][-1]['locals'][keywords]))
         self.assertIn('password', payload['data']['body']['trace']['frames'][-1]['locals'][keywords])
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals'][keywords]['password'], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals'][keywords]['password'], r'\*+')
         self.assertIn('clear', payload['data']['body']['trace']['frames'][-1]['locals'][keywords])
         self.assertEqual('text', payload['data']['body']['trace']['frames'][-1]['locals'][keywords]['clear'])
 
@@ -1481,12 +1448,11 @@ class RollbarTest(BaseTest):
 
         payload = send_payload.call_args[0][0]
 
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals']['password'], r'\*+')
-        six.assertRegex(self, payload['data']['body']['trace']['frames'][-1]['locals']['Password'], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['password'], r'\*+')
+        self.assertRegex(payload['data']['body']['trace']['frames'][-1]['locals']['Password'], r'\*+')
         self.assertIn('_invalid', payload['data']['body']['trace']['frames'][-1]['locals'])
 
-        binary_type_name = 'str' if python_major_version() < 3 else 'bytes'
-        undecodable_message = '<Undecodable type:(%s) base64:(%s)>' % (binary_type_name, base64.b64encode(invalid).decode('ascii'))
+        undecodable_message = '<Undecodable type:(%s) base64:(%s)>' % ('bytes', base64.b64encode(invalid).decode('ascii'))
         self.assertEqual(undecodable_message, payload['data']['body']['trace']['frames'][-1]['locals']['_invalid'])
 
     @mock.patch('rollbar.send_payload')
@@ -1799,19 +1765,19 @@ class RollbarTest(BaseTest):
         self.assertEqual('I am from NSA', unscrubbed['headers']['Authorization'])
 
         scrubbed = rollbar._transform(unscrubbed)
-        six.assertRegex(self, scrubbed['url'], r'http://example.com/the/path\?(q=hello&password=-+)|(password=-+&q=hello)')
+        self.assertRegex(scrubbed['url'], r'http://example.com/the/path\?(q=hello&password=-+)|(password=-+&q=hello)')
 
         self.assertEqual(scrubbed['GET']['q'], 'hello')
-        six.assertRegex(self, scrubbed['GET']['password'], r'\*+')
+        self.assertRegex(scrubbed['GET']['password'], r'\*+')
 
         self.assertEqual(scrubbed['POST']['foo'], 'bar')
-        six.assertRegex(self, scrubbed['POST']['confirm_password'], r'\*+')
-        six.assertRegex(self, scrubbed['POST']['token'], r'\*+')
+        self.assertRegex(scrubbed['POST']['confirm_password'], r'\*+')
+        self.assertRegex(scrubbed['POST']['token'], r'\*+')
 
         self.assertEqual('5.6.7.8', scrubbed['headers']['X-Real-Ip'])
 
-        six.assertRegex(self, scrubbed['headers']['Cookies'], r'\*+')
-        six.assertRegex(self, scrubbed['headers']['Authorization'], r'\*+')
+        self.assertRegex(scrubbed['headers']['Cookies'], r'\*+')
+        self.assertRegex(scrubbed['headers']['Authorization'], r'\*+')
 
     def test_filter_ip_no_user_ip(self):
         request_data = {'something': 'but no ip'}

--- a/rollbar/test/test_scrub_redact_transform.py
+++ b/rollbar/test/test_scrub_redact_transform.py
@@ -1,11 +1,6 @@
-try:
-    # Python 3
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2.7
-    from collections import Mapping
+from collections.abc import Mapping
 
-from rollbar.lib import text, transforms
+from rollbar.lib import transforms
 from rollbar.lib.transforms.scrub_redact import ScrubRedactTransform, REDACT_REF
 
 from rollbar.test import BaseTest
@@ -19,7 +14,7 @@ NOT_REDACT_REF = NotRedactRef()
 try:
     SCRUBBED = '*' * len(REDACT_REF)
 except:
-    SCRUBBED = '*' * len(text(REDACT_REF))
+    SCRUBBED = '*' * len(str(REDACT_REF))
 
 
 class ScrubRedactTransformTest(BaseTest):

--- a/rollbar/test/test_scrub_transform.py
+++ b/rollbar/test/test_scrub_transform.py
@@ -1,11 +1,6 @@
 import copy
 
-try:
-    # Python 3
-    from collections.abc import Mapping
-except ImportError:
-    # Python 2.7
-    from collections import Mapping
+from collections.abc import Mapping
 
 from rollbar.lib import transforms
 from rollbar.lib.transforms.scrub import ScrubTransform

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -2,7 +2,6 @@ import sys
 from array import array
 from collections import deque
 
-import six
 from rollbar import DEFAULT_LOCALS_SIZES
 from rollbar.lib import transforms
 from rollbar.lib.transforms.shortener import ShortenerTransform
@@ -71,9 +70,7 @@ class ShortenerTransformTest(BaseTest):
         self._assert_shortened('string', expected)
 
     def test_shorten_long(self):
-        expected = '179556827339164684...002504519623752387L'
-        if six.PY3:
-            expected = '179556827339164684...5002504519623752387'
+        expected = '179556827339164684...5002504519623752387'
         self._assert_shortened('long', expected)
 
     def test_shorten_mapping(self):
@@ -114,9 +111,7 @@ class ShortenerTransformTest(BaseTest):
         self._assert_shortened('deque', expected)
 
     def test_shorten_other(self):
-        expected = '<rollbar.test.test_shortener_transform.TestCla...'
-        if six.PY3:
-            expected = '<rollbar.test.test_shortener_transform.TestClas...'
+        expected = '<rollbar.test.test_shortener_transform.TestClas...'
         self._assert_shortened('other', expected)
 
     def test_shorten_object(self):

--- a/rollbar/test/twisted_tests/test_twisted.py
+++ b/rollbar/test/twisted_tests/test_twisted.py
@@ -5,10 +5,7 @@ Tests for Twisted instrumentation
 import json
 import sys
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import rollbar
 

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ with open(INIT_PATH) as fd:
 tests_require = [
     'webob',
     'blinker',
-    'mock<=3.0.5; python_version < "3.3"',
-    'enum34; python_version < "3.4"',
-    'httpx; python_version >= "3.6"',
+    'httpx',
     'aiocontextvars; python_version == "3.6"'
 ]
 
@@ -46,17 +44,14 @@ setup(
     url='http://github.com/rollbar/pyrollbar',
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 5 - Production/Stable",
@@ -78,16 +73,7 @@ setup(
         "Topic :: System :: Monitoring",
         ],
     install_requires=[
-        # The currently used version of `setuptools` has a bug,
-        # so the version requirements are not properly respected.
-        #
-        # In the current version, `requests>= 0.12.1`
-        # always installs the latest version of the package.
-        'requests>=0.12.1; python_version == "2.7"',
-        'requests>=0.12.1; python_version >= "3.6"',
-        'requests>=0.12.1; python_version == "3.5"',
-        'requests>=0.12.1; python_version == "3.4"',
-        'six>=1.9.0'
+        'requests>=0.12.1',
     ],
     tests_require=tests_require,
 )


### PR DESCRIPTION
## Description of the change

This PR removes support for Python 2. Python 2 support is being removed in v1.0.0, and so this commit also bumps the version to `v1.0.0beta0`.

Doing this allowed a bunch of code to be simplified. This reduced function calls, memory allocations, generally increased performance. Some early benchmarks showed that the call stack data collection sanitization and serialization is 18.7% faster than previously.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
