### PR TITLE
Fixed #436 `WSGIRequest` has no attribute `sensitive_post_parameters`.

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -24,7 +24,7 @@ import requests
 from rollbar.lib import events, filters, dict_merge, transport, defaultJSONEncode
 
 
-__version__ = '1.0.0b0'
+__version__ = '1.0.0b1'
 __log_name__ = 'rollbar'
 log = logging.getLogger(__log_name__)
 

--- a/rollbar/contrib/django/middleware.py
+++ b/rollbar/contrib/django/middleware.py
@@ -185,13 +185,23 @@ def _should_ignore_404(url):
     return any(p.search(url) for p in url_patterns)
 
 def _apply_sensitive_post_params(request):
-    if request.sensitive_post_parameters:
-        mutable = request.POST._mutable
-        request.POST._mutable = True
-        for param in request.sensitive_post_parameters:
-            if param in request.POST:
-                request.POST[param] = "******"
-        request.POST._mutable = mutable
+    sensitive_post_parameters = getattr(
+        request, "sensitive_post_parameters", []
+    )
+    if not sensitive_post_parameters:
+        return
+    mutable = request.POST._mutable
+    request.POST._mutable = True
+
+    if sensitive_post_parameters == "__ALL__":
+        for param in request.POST:
+            request.POST[param] = "******"
+        return
+
+    for param in sensitive_post_parameters:
+        if param in request.POST:
+            request.POST[param] = "******"
+    request.POST._mutable = mutable
 
 class RollbarNotifierMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):


### PR DESCRIPTION
## Description of the change

The `sensitive_post_parameters` attribute is not guarenteed to exist on the request object in Django. This PR resolves that issue, and also adds some logic that to account for the possible value `"__ALL__"`. See...

https://github.com/django/django/blob/814e7bc22062eeae4be9f189e89027e28d5dd290/django/views/debug.py#L211

This PR also bumps the version of the beta release to `v1.0.0b1`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Related issues

- Fix #436

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
