### PR TITLE
traverse object for recursive shortening

### DIFF
--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -47,6 +47,8 @@ class ShortenerTransform(Transform):
 
         return self._repr.maxother
 
+    def _get_max_level(self):
+        return getattr(self._repr, 'maxlevel')
     def _shorten_sequence(self, obj, max_keys):
         _len = len(obj)
         if _len <= max_keys:
@@ -77,7 +79,7 @@ class ShortenerTransform(Transform):
 
         return self._repr.repr(obj)
 
-    def traverse_obj(self, obj):
+    def traverse_obj(self, obj, level=1):
         def seq_iter(o):
             return o if isinstance(o, dict) else range(len(o))
 
@@ -85,10 +87,16 @@ class ShortenerTransform(Transform):
             max_size = self._get_max_size(obj[k])
             if isinstance(obj[k], dict):
                 obj[k] = self._shorten_mapping(obj[k], max_size)
-                self.traverse_obj(obj[k])
+                if level == self._get_max_level():
+                    del obj[k]
+                    return
+                self.traverse_obj(obj[k], level + 1)
             elif isinstance(obj[k], sequence_types):
                 obj[k] = self._shorten_sequence(obj[k], max_size)
-                self.traverse_obj(obj[k])
+                if level == self._get_max_level():
+                    del obj[k]
+                    return
+                self.traverse_obj(obj[k], level + 1)
             else:
                 obj[k] = self._shorten(obj[k])
         return obj

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -77,11 +77,22 @@ class ShortenerTransform(Transform):
 
         return self._repr.repr(obj)
 
+    def traverse_dict(self, d):
+        max_size = self._get_max_size(d)
+        d = self._shorten_mapping(d, max_size)
+        for k, v in d.items():
+            if isinstance(v, dict):
+                self.traverse_dict(v)
+            else:
+                d[k] = self._shorten(v)
+        return d
+
     def _shorten(self, val):
         max_size = self._get_max_size(val)
 
         if isinstance(val, dict):
-            return self._shorten_mapping(val, max_size)
+            return self.traverse_dict(val)
+
         if isinstance(val, (string_types, sequence_types)):
             return self._shorten_sequence(val, max_size)
 

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -105,6 +105,8 @@ class ShortenerTransform(Transform):
 
         if isinstance(val, sequence_types):
             val = self._shorten_sequence(val, max_size)
+            if isinstance(val, string_types):
+                return val
             return self.traverse_obj(val)
 
         if isinstance(val, number_types):

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -78,8 +78,6 @@ class ShortenerTransform(Transform):
         return self._repr.repr(obj)
 
     def traverse_dict(self, d):
-        max_size = self._get_max_size(d)
-        d = self._shorten_mapping(d, max_size)
         for k, v in d.items():
             if isinstance(v, dict):
                 max_size = self._get_max_size(v)
@@ -93,6 +91,8 @@ class ShortenerTransform(Transform):
         max_size = self._get_max_size(val)
 
         if isinstance(val, dict):
+            max_size = self._get_max_size(val)
+            val = self._shorten_mapping(val, max_size)
             return self.traverse_dict(val)
 
         if isinstance(val, (string_types, sequence_types)):

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -82,7 +82,9 @@ class ShortenerTransform(Transform):
         d = self._shorten_mapping(d, max_size)
         for k, v in d.items():
             if isinstance(v, dict):
-                self.traverse_dict(v)
+                max_size = self._get_max_size(v)
+                d[k] = self._shorten_mapping(v, max_size)
+                self.traverse_dict(d[k])
             else:
                 d[k] = self._shorten(v)
         return d

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -77,32 +77,21 @@ class ShortenerTransform(Transform):
 
         return self._repr.repr(obj)
 
-    def traverse_obj(self, d):
-        if isinstance(d, dict):
-            for k, v in d.items():
-                if isinstance(v, dict):
-                    max_size = self._get_max_size(v)
-                    d[k] = self._shorten_mapping(v, max_size)
-                    self.traverse_obj(d[k])
-                elif isinstance(v,  sequence_types):
-                    max_size = self._get_max_size(v)
-                    d[k] = self._shorten_sequence(v, max_size)
-                    self.traverse_obj(d[k])
-                else:
-                    d[k] = self._shorten(v)
-        elif isinstance(d, sequence_types):
-            for i in range(len(d)):
-                if isinstance(d[i], dict):
-                    max_size = self._get_max_size(d[i])
-                    d[i] = self._shorten_mapping(d[i], max_size)
-                    self.traverse_obj(d[i])
-                elif isinstance(d[i],  sequence_types):
-                    max_size = self._get_max_size(d[i])
-                    d[i] = self._shorten_sequence(d[i], max_size)
-                    self.traverse_obj(d[i])
-                else:
-                    d[i] = self._shorten(d[i])
-        return d
+    def traverse_obj(self, obj):
+        def seq_iter(o):
+            return o if isinstance(o, dict) else range(len(o))
+
+        for k in seq_iter(obj):
+            max_size = self._get_max_size(obj[k])
+            if isinstance(obj[k], dict):
+                obj[k] = self._shorten_mapping(obj[k], max_size)
+                self.traverse_obj(obj[k])
+            elif isinstance(obj[k], sequence_types):
+                obj[k] = self._shorten_sequence(obj[k], max_size)
+                self.traverse_obj(obj[k])
+            else:
+                obj[k] = self._shorten(obj[k])
+        return obj
 
     def _shorten(self, val):
         max_size = self._get_max_size(val)

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -39,7 +39,8 @@ class ShortenerTransformTest(BaseTest):
             'deque': deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 15),
             'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName(),
             'list_max_level': [1, [2, [3, [4, ["good_5", ["bad_6", ["bad_7"]]]]]]],
-            'dict_max_level': {1: 1, 2: {3: {4: {"level4": "good", "level5": {"toplevel": "ok", 6: {7: {}}}}}}}
+            'dict_max_level': {1: 1, 2: {3: {4: {"level4": "good", "level5": {"toplevel": "ok", 6: {7: {}}}}}}},
+            'list_multi_level':  [1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]
         }
 
     def _assert_shortened(self, key, expected):
@@ -48,7 +49,7 @@ class ShortenerTransformTest(BaseTest):
 
         if key == 'dict':
             self.assertEqual(expected, len(result[key]))
-        elif key in ('list_max_level', 'dict_max_level'):
+        elif key in ('list_max_level', 'dict_max_level', 'list_multi_level'):
             self.assertEqual(expected,  result[key])
         else:
             # the repr output can vary between Python versions
@@ -56,7 +57,7 @@ class ShortenerTransformTest(BaseTest):
 
         if key == 'other':
             self.assertIn(expected, stripped_result_key)
-        elif key not in ('dict', 'list_max_level', 'dict_max_level'):
+        elif key not in ('dict', 'list_max_level', 'dict_max_level', 'list_multi_level'):
             self.assertEqual(expected, stripped_result_key)
 
         # make sure nothing else was shortened
@@ -89,6 +90,10 @@ class ShortenerTransformTest(BaseTest):
     def test_shorten_list_max_level(self):
         expected = [1, [2, [3, [4, ['good_5']]]]]
         self._assert_shortened('list_max_level', expected)
+
+    def test_shorten_list_multi_level(self):
+        expected = [1, '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]']
+        self._assert_shortened('list_multi_level', expected)
 
     def test_shorten_dict_max_level(self):
         expected = {1: 1, 2: {3: {4: {'level4': 'good', 'level5': {'toplevel': 'ok'}}}}}

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -37,7 +37,9 @@ class ShortenerTransformTest(BaseTest):
             'frozenset': frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
             'array': array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
             'deque': deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 15),
-            'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName()
+            'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName(),
+            'list_max_level': [1, [2, [3, [4, ["good_5", ["bad_6", ["bad_7"]]]]]]],
+            'dict_max_level': {1: 1, 2: {3: {4: {"level4": "good", "level5": {"toplevel": "ok", 6: {7: {}}}}}}}
         }
 
     def _assert_shortened(self, key, expected):
@@ -46,13 +48,15 @@ class ShortenerTransformTest(BaseTest):
 
         if key == 'dict':
             self.assertEqual(expected, len(result))
+        elif key in ('list_max_level', 'dict_max_level'):
+            self.assertEqual(expected,  result[key])
         else:
             # the repr output can vary between Python versions
             stripped_result_key = result[key].strip("'\"u")
 
         if key == 'other':
             self.assertIn(expected, stripped_result_key)
-        elif key != 'dict':
+        elif key not in ('dict', 'list_max_level', 'dict_max_level'):
             self.assertEqual(expected, stripped_result_key)
 
         # make sure nothing else was shortened
@@ -81,6 +85,14 @@ class ShortenerTransformTest(BaseTest):
     def test_shorten_list(self):
         expected = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]'
         self._assert_shortened('list', expected)
+
+    def test_shorten_list_max_level(self):
+        expected = [1, [2, [3, [4, ['good_5']]]]]
+        self._assert_shortened('list_max_level', expected)
+
+    def test_shorten_dict_max_level(self):
+        expected = {1: 1, 2: {3: {4: {'level4': 'good', 'level5': {'toplevel': 'ok'}}}}}
+        self._assert_shortened('dict_max_level', expected)
 
     def test_shorten_tuple(self):
         expected = '(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...)'

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -47,7 +47,7 @@ class ShortenerTransformTest(BaseTest):
         result = transforms.transform(self.data, shortener)
 
         if key == 'dict':
-            self.assertEqual(expected, len(result))
+            self.assertEqual(expected, len(result[key]))
         elif key in ('list_max_level', 'dict_max_level'):
             self.assertEqual(expected,  result[key])
         else:


### PR DESCRIPTION
## Description of the change

Traverse dictionary for recursive shortening 

```python
dict = {"l": "","2":2, "3": 3, "4": 4, "5":5,
        "6":6, "7": 7, "9" :9, "10": 10, "b": {"f": "sdf",
        "2":2, "3": 3, "4": 4, "5":5, "6":6, "7": 7, "9" :9, "10": 10, "11": 11, "12":12} }

for i in range(1, 10240):
    dict["l"] += "a"
    dict["b"]["f"] += "s"
```

output:

![#6: NameError: name 'main_app_loop' is not defined 2024-04-15 23-31-12](https://github.com/rollbar/pyrollbar/assets/76971683/7f62fdba-7617-4d7e-83e3-3502998c9de1)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
