### PR TITLE
Fixed shortener multi level shortening

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -402,12 +402,6 @@ def init(access_token, environment='production', scrub_fields=None, url_fields=N
     #       trace frame values using the ShortReprTransform.
     _serialize_transform = SerializableTransform(safe_repr=SETTINGS['locals']['safe_repr'],
                                                  safelist_types=SETTINGS['locals']['safelisted_types'])
-    _transforms = [
-        ScrubRedactTransform(),
-        _serialize_transform,
-        ScrubTransform(suffixes=[(field,) for field in SETTINGS['scrub_fields']], redact_char='*'),
-        ScrubUrlTransform(suffixes=[(field,) for field in SETTINGS['url_fields']], params_to_scrub=SETTINGS['scrub_fields'])
-    ]
 
     # A list of key prefixes to apply our shortener transform to. The request
     # being included in the body key is old behavior and is being retained for
@@ -431,7 +425,13 @@ def init(access_token, environment='production', scrub_fields=None, url_fields=N
     shortener = ShortenerTransform(safe_repr=SETTINGS['locals']['safe_repr'],
                                    keys=shortener_keys,
                                    **SETTINGS['locals']['sizes'])
-    _transforms.append(shortener)
+    _transforms = [
+        shortener,
+        ScrubRedactTransform(),
+        _serialize_transform,
+        ScrubTransform(suffixes=[(field,) for field in SETTINGS['scrub_fields']], redact_char='*'),
+        ScrubUrlTransform(suffixes=[(field,) for field in SETTINGS['url_fields']], params_to_scrub=SETTINGS['scrub_fields'])
+    ]
     _threads = queue.Queue()
     events.reset()
     filters.add_builtin_filters(SETTINGS)

--- a/rollbar/lib/__init__.py
+++ b/rollbar/lib/__init__.py
@@ -33,26 +33,39 @@ def prefix_match(key, prefixes):
     return False
 
 
-def key_in(key, keys):
+def key_in(key, canonicals):
     if not key:
         return False
 
-    for k in keys:
-        if key_match(k, key):
+    for c in canonicals:
+        if key_match(key, c):
             return True
 
     return False
 
 
-def key_match(key1, key2):
-    if len(key1) != len(key2):
+def key_depth(key, canonicals) -> int:
+    if not key:
+        return 0
+
+    for c in canonicals:
+        if key_match(key, c):
+            return len(c)
+
+    return 0
+
+
+def key_match(key, canonical):
+    i = 0
+    for k, c in zip(key, canonical):
+        i += 1
+        if '*' == c:
+            continue
+        if c == k:
+            continue
         return False
 
-    for p1, p2 in zip(key1, key2):
-        if '*' == p1 or '*' == p2:
-            continue
-        if p1 == p2:
-            continue
+    if i < len(canonical) - 1:
         return False
 
     return True

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -47,8 +47,6 @@ class ShortenerTransform(Transform):
 
         return self._repr.maxother
 
-    def _get_max_level(self):
-        return getattr(self._repr, 'maxlevel')
     def _shorten_sequence(self, obj, max_keys):
         _len = len(obj)
         if _len <= max_keys:
@@ -79,43 +77,13 @@ class ShortenerTransform(Transform):
 
         return self._repr.repr(obj)
 
-    def traverse_obj(self, obj, level=1):
-        def seq_iter(o):
-            return o if isinstance(o, dict) else range(len(o))
-
-        for k in seq_iter(obj):
-            max_size = self._get_max_size(obj[k])
-            if isinstance(obj[k], dict):
-                obj[k] = self._shorten_mapping(obj[k], max_size)
-                if level == self._get_max_level():
-                    del obj[k]
-                    return
-                self.traverse_obj(obj[k], level + 1)
-            elif isinstance(obj[k], sequence_types):
-                obj[k] = self._shorten_sequence(obj[k], max_size)
-                if level == self._get_max_level():
-                    del obj[k]
-                    return
-                self.traverse_obj(obj[k], level + 1)
-            else:
-                obj[k] = self._shorten(obj[k])
-        return obj
-
     def _shorten(self, val):
         max_size = self._get_max_size(val)
 
         if isinstance(val, dict):
-            val = self._shorten_mapping(val, max_size)
-            return self.traverse_obj(val)
-
-        if isinstance(val, string_types):
+            return self._shorten_mapping(val, max_size)
+        if isinstance(val, (string_types, sequence_types)):
             return self._shorten_sequence(val, max_size)
-
-        if isinstance(val, sequence_types):
-            val = self._shorten_sequence(val, max_size)
-            if isinstance(val, string_types):
-                return val
-            return self.traverse_obj(val)
 
         if isinstance(val, number_types):
             return self._shorten_basic(val, self._repr.maxlong)

--- a/rollbar/test/test_lib.py
+++ b/rollbar/test/test_lib.py
@@ -1,23 +1,59 @@
-from rollbar.lib import dict_merge, prefix_match
+from rollbar.lib import dict_merge, prefix_match, key_match, key_depth
 
 from rollbar.test import BaseTest
 
 
 class RollbarLibTest(BaseTest):
+    def test_prefix_match(self):
+        key = ['password', 'argspec', '0']
+        self.assertTrue(prefix_match(key, [['password']]))
+
+    def test_prefix_match_dont_match(self):
+        key = ['environ', 'argspec', '0']
+        self.assertFalse(prefix_match(key, [['password']]))
+
+    def test_key_match(self):
+        canonical = ['body', 'trace', 'frames', '*', 'locals', '*']
+        key = ['body', 'trace', 'frames', 5, 'locals', 'foo']
+
+        self.assertTrue(key_match(key, canonical))
+
+    def test_key_match_dont_match(self):
+        canonical = ['body', 'trace', 'frames', '*', 'locals', '*']
+        key = ['body', 'trace', 'frames', 5, 'bar', 'foo']
+
+        self.assertFalse(key_match(key, canonical))
+
+    def test_key_match_wildcard_end(self):
+        canonical = ['body', 'trace', 'frames', '*', 'locals', '*']
+        key = ['body', 'trace', 'frames', 5, 'locals', 'foo', 'bar']
+
+        self.assertTrue(key_match(key, canonical))
+
+    def test_key_depth(self):
+        canonicals = [['body', 'trace', 'frames', '*', 'locals', '*']]
+        key = ['body', 'trace', 'frames', 5, 'locals', 'foo']
+
+        self.assertEqual(6, key_depth(key, canonicals))
+
+    def test_key_depth_dont_match(self):
+        canonicals = [['body', 'trace', 'frames', '*', 'locals', '*']]
+        key = ['body', 'trace', 'frames', 5, 'bar', 'foo']
+
+        self.assertEqual(0, key_depth(key, canonicals))
+
+    def test_key_depth_wildcard_end(self):
+        canonicals = [['body', 'trace', 'frames', '*']]
+        key = ['body', 'trace', 'frames', 5, 'locals', 'foo', 'bar']
+
+        self.assertEqual(4, key_depth(key, canonicals))
+
     def test_dict_merge_not_dict(self):
         a = {'a': {'b': 42}}
         b = 99
         result = dict_merge(a, b)
 
         self.assertEqual(99, result)
-
-    def test_prefix_match(self):
-        key = ['password', 'argspec', '0']
-        self.assertTrue(prefix_match(key, [['password']]))
-
-    def test_prefix_match(self):
-        key = ['environ', 'argspec', '0']
-        self.assertFalse(prefix_match(key, [['password']]))
 
     def test_dict_merge_dicts_independent(self):
         a = {'a': {'b': 42}}

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -37,10 +37,7 @@ class ShortenerTransformTest(BaseTest):
             'frozenset': frozenset([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
             'array': array('l', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
             'deque': deque([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], 15),
-            'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName(),
-            'list_max_level': [1, [2, [3, [4, ["good_5", ["bad_6", ["bad_7"]]]]]]],
-            'dict_max_level': {1: 1, 2: {3: {4: {"level4": "good", "level5": {"toplevel": "ok", 6: {7: {}}}}}}},
-            'list_multi_level':  [1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]
+            'other': TestClassWithAVeryVeryVeryVeryVeryVeryVeryLongName()
         }
 
     def _assert_shortened(self, key, expected):
@@ -48,16 +45,14 @@ class ShortenerTransformTest(BaseTest):
         result = transforms.transform(self.data, shortener)
 
         if key == 'dict':
-            self.assertEqual(expected, len(result[key]))
-        elif key in ('list_max_level', 'dict_max_level', 'list_multi_level'):
-            self.assertEqual(expected,  result[key])
+            self.assertEqual(expected, len(result))
         else:
             # the repr output can vary between Python versions
             stripped_result_key = result[key].strip("'\"u")
 
         if key == 'other':
             self.assertIn(expected, stripped_result_key)
-        elif key not in ('dict', 'list_max_level', 'dict_max_level', 'list_multi_level'):
+        elif key != 'dict':
             self.assertEqual(expected, stripped_result_key)
 
         # make sure nothing else was shortened
@@ -86,18 +81,6 @@ class ShortenerTransformTest(BaseTest):
     def test_shorten_list(self):
         expected = '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]'
         self._assert_shortened('list', expected)
-
-    def test_shorten_list_max_level(self):
-        expected = [1, [2, [3, [4, ['good_5']]]]]
-        self._assert_shortened('list_max_level', expected)
-
-    def test_shorten_list_multi_level(self):
-        expected = [1, '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...]']
-        self._assert_shortened('list_multi_level', expected)
-
-    def test_shorten_dict_max_level(self):
-        expected = {1: 1, 2: {3: {4: {'level4': 'good', 'level5': {'toplevel': 'ok'}}}}}
-        self._assert_shortened('dict_max_level', expected)
 
     def test_shorten_tuple(self):
         expected = '(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...)'


### PR DESCRIPTION
## Description of the change

This PR fixes the key matching shortener logic that was preventing deep shortening of the payload.

There are a few significant changes here:

1. The shortner transform is moved to the beginning of the transforms. There is no point scrubbing data if we are just going to remove it.
2. A shortener key that ends with a `'*'` key will not only match everything at that level it will also match all of the children of that key.
3.  The shortener keys are uses to set a "base level" for `maxlevel`. Each level deep than the shortener key is checked to see if it exceeds the `maxlevel`. This is only applied if the key matches and ends with a final `'*'` key.

Because this may have a meaningful change in the frame data we are sending, I think this should be a minor change not a patch. I also think we should release this as a beta initially. This would be `v1.1.0-beta0`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- #447
- #412

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
