### PR TITLE
Support pathlib.Path() objects

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -1118,8 +1118,14 @@ def _check_add_locals(frame, frame_num, total_frames):
     """
     # Include the last frames locals
     # Include any frame locals that came from a file in the project's root
+    root = SETTINGS.get('root')
+    if root:
+        # coerce to string, in case root is a Path object
+        root = str(root)
+    else:
+        root = ''
     return any(((frame_num == total_frames - 1),
-                ('root' in SETTINGS and (frame.get('filename') or '').lower().startswith((SETTINGS['root'] or '').lower()))))
+                ('root' in SETTINGS and (frame.get('filename') or '').lower().startswith(root.lower()))))
 
 
 def _get_actual_request(request):

--- a/rollbar/lib/transform.py
+++ b/rollbar/lib/transform.py
@@ -32,5 +32,8 @@ class Transform(object):
     def transform_boolean(self, o, key=None):
         return self.default(o, key=key)
 
+    def transform_path(self, o, key=None):
+        return self.default(str(o), key=key)
+
     def transform_custom(self, o, key=None):
         return self.default(o, key=key)

--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -79,6 +79,7 @@ def _transform(obj, transform, key=None):
         "list_handler": lambda o, key=None: do_transform("list", o, key=key),
         "set_handler": lambda o, key=None: do_transform("set", o, key=key),
         "mapping_handler": lambda o, key=None: do_transform("dict", o, key=key),
+        "path_handler": lambda o, key=None: do_transform("path", o, key=key),
         "circular_reference_handler": lambda o, key=None, ref_key=None: do_transform(
             "circular_reference", o, key=key, ref_key=ref_key
         ),

--- a/rollbar/lib/traverse.py
+++ b/rollbar/lib/traverse.py
@@ -1,5 +1,5 @@
 import logging
-
+from pathlib import Path
 
 from rollbar.lib import binary_type, string_types, circular_reference_label
 
@@ -16,6 +16,7 @@ from rollbar.lib.type_info import (
     LIST,
     SET,
     STRING,
+    PATH,
 )
 
 
@@ -49,6 +50,9 @@ def _noop_set(a, **_):
 def _noop_mapping(a, **_):
     return dict(a)
 
+def _noop_path(a, **_):
+    return Path(a)
+
 
 _default_handlers = {
     CIRCULAR: _noop_circular,
@@ -58,6 +62,7 @@ _default_handlers = {
     NAMEDTUPLE: _noop_namedtuple,
     LIST: _noop_list,
     SET: _noop_set,
+    PATH: _noop_path,
     MAPPING: _noop_mapping,
 }
 
@@ -71,6 +76,7 @@ def traverse(
     list_handler=_default_handlers[LIST],
     set_handler=_default_handlers[SET],
     mapping_handler=_default_handlers[MAPPING],
+    path_handler=_default_handlers[PATH],
     default_handler=_default_handlers[DEFAULT],
     circular_reference_handler=_default_handlers[CIRCULAR],
     allowed_circular_reference_types=None,
@@ -97,6 +103,7 @@ def traverse(
         "list_handler": list_handler,
         "set_handler": set_handler,
         "mapping_handler": mapping_handler,
+        "path_handler": path_handler,
         "default_handler": default_handler,
         "circular_reference_handler": circular_reference_handler,
         "allowed_circular_reference_types": allowed_circular_reference_types,
@@ -137,6 +144,8 @@ def traverse(
                 {k: traverse(v, key=key + (k,), **kw) for k, v in obj.items()},
                 key=key,
             )
+        elif obj_type is PATH:
+            return path_handler(obj, key=key)
         elif obj_type is DEFAULT:
             for handler_type, handler in custom_handlers.items():
                 if isinstance(obj, handler_type):

--- a/rollbar/lib/type_info.py
+++ b/rollbar/lib/type_info.py
@@ -2,6 +2,7 @@ from rollbar.lib import binary_type, string_types
 
 
 from collections.abc import Mapping, Sequence, Set
+from pathlib import Path
 
 
 CIRCULAR = -1
@@ -12,6 +13,7 @@ NAMEDTUPLE = 3
 LIST = 4
 SET = 5
 STRING = 6
+PATH = 7
 
 
 def get_type(obj):
@@ -33,6 +35,9 @@ def get_type(obj):
     if isinstance(obj, Sequence):
         return LIST
 
+    if isinstance(obj, Path):
+        return PATH
+
     return DEFAULT
 
 
@@ -45,5 +50,6 @@ __all__ = [
     "LIST",
     "SET",
     "STRING",
+    "PATH",
     "get_type",
 ]


### PR DESCRIPTION
Fixes #345. This change allows Rollbar to convert [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) objects to regular strings for serialization purposes. This also prevents Rollbar from crashing in the default Django configuration, where `settings.BASE_DIR` is a `PosixPath` object.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
