### PR TITLE
Removed tox from CI and called unittest directly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Python Test dependencies
+        run: pip install requests webob blinker httpx
+
       - name: Install Python 3.6 dependencies
         if: ${{ contains(matrix.python-version, '3.6') }}
         # typing-extensions dropped support for Python 3.6 in version 4.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,5 @@ jobs:
         if: ${{ contains(matrix.framework, 'FASTAPI_VERSION') }}
         run: pip install fastapi==$FASTAPI_VERSION
 
-      - name: Install Tox
-        run: pip install tox
-
-      - name: Run tests (skip on Python 3.6)
-        if: ${{ !contains(matrix.python-version, '3.6') }}
-        run: tox
-
-      - name: Run tests (Python 3.6)
-        if: ${{ contains(matrix.python-version, '3.6') }}
+      - name: Run tests
         run: python -m unittest rollbar.test.discover


### PR DESCRIPTION
## Description of the change

Using a tox environment ignores the frameworks and versions in the CI matrix. This replaces tox with just calling unittest directly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
