### PR TITLE
Fixed #398 FastAPI integration fails if docs are disabled.

### DIFF
--- a/rollbar/contrib/fastapi/utils.py
+++ b/rollbar/contrib/fastapi/utils.py
@@ -96,17 +96,20 @@ def get_installed_middlewares(app):
     return middlewares
 
 
-def has_bare_routing(app_or_router):
-    expected_app_routes = 4
-    expected_router_routes = 0
+def has_bare_routing(app_or_router: FastAPI | APIRouter):
+    if not isinstance(app_or_router, (FastAPI, APIRouter)):
+        return False
 
-    if (
-        isinstance(app_or_router, FastAPI)
-        and expected_app_routes != len(app_or_router.routes)
-    ) or (
-        isinstance(app_or_router, APIRouter)
-        and expected_router_routes != len(app_or_router.routes)
-    ):
+    urls = [
+        getattr(app_or_router, 'openapi_url', None),
+        getattr(app_or_router, 'docs_url', None),
+        getattr(app_or_router, 'redoc_url', None),
+        getattr(app_or_router, 'swagger_ui_oauth2_redirect_url', None),
+    ]
+
+    for route in app_or_router.routes:
+        if route is None or route.path in urls:
+            continue
         return False
 
     return True

--- a/rollbar/contrib/fastapi/utils.py
+++ b/rollbar/contrib/fastapi/utils.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+from typing import Union
 
 import fastapi
 from fastapi import APIRouter, FastAPI
@@ -96,7 +97,7 @@ def get_installed_middlewares(app):
     return middlewares
 
 
-def has_bare_routing(app_or_router: FastAPI | APIRouter):
+def has_bare_routing(app_or_router: Union[FastAPI, APIRouter]):
     if not isinstance(app_or_router, (FastAPI, APIRouter)):
         return False
 

--- a/rollbar/test/fastapi_tests/test_utils.py
+++ b/rollbar/test/fastapi_tests/test_utils.py
@@ -122,6 +122,22 @@ class UtilsBareRoutingTest(BaseTest):
 
         self.assertFalse(has_bare_routing(app))
 
+    def test_should_return_true_if_docs_disabled(self):
+        from fastapi import APIRouter, FastAPI
+        from rollbar.contrib.fastapi.utils import has_bare_routing
+
+        app = FastAPI(docs_url=None, redoc_url=None)
+        self.assertTrue(has_bare_routing(app))
+
+        app = FastAPI(docs_url=None)
+        self.assertTrue(has_bare_routing(app))
+
+        app = FastAPI(redoc_url=None)
+        self.assertTrue(has_bare_routing(app))
+
+        router = APIRouter()
+        self.assertTrue(has_bare_routing(router))
+
 @unittest.skipUnless(
     FASTAPI_INSTALLED and ALLOWED_PYTHON_VERSION, 'FastAPI requires Python3.6+'
 )


### PR DESCRIPTION
## Description of the change

This fixes a bug with the FastAPI integration. Our previous implementation assumed the app would have docs enabled. This resolves that and also allows fixes the issue for two other URLs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- #398

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
