### PR TITLE
Added support for Python3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
         framework:
           - NONE
           - FLASK_VERSION=1.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           # Django
           - framework: DJANGO_VERSION=3.2.25
             python-version: 3.11
+          - framework: DJANGO_VERSION=3.2.25
+            python-version: 3.12
           - framework: DJANGO_VERSION=4.2.15
             python-version: 3.6
           - framework: DJANGO_VERSION=4.2.15
@@ -61,6 +63,8 @@ jobs:
           # Twisted
           - framework: TWISTED_VERSION=20.3.0
             python-version: 3.11
+          - framework: TWISTED_VERSION=20.3.0
+            python-version: 3.12
           - framework: TWISTED_VERSION=22.10.0
             python-version: 3.6
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python notifier for reporting exceptions, errors, and log messages to [Rollbar](
 
 | PyRollbar Version | Python Version Compatibility                  | Support Level       |
 |-------------------|-----------------------------------------------|---------------------|
-| 1.0.0             | 3.6, 3.7. 3.8, 3.9, 3.10, 3.11                | Full                |
+| 1.0.0             | 3.6, 3.7. 3.8, 3.9, 3.10, 3.11, 3.12          | Full                |
 | 0.16.3            | 2.7, 3.4, 3.5, 3.6, 3.7. 3.8, 3.9, 3.10, 3.11 | Security Fixes Only |
 
 #### Support Level Definitions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/rollbar/test/fastapi_tests/test_logger.py
+++ b/rollbar/test/fastapi_tests/test_logger.py
@@ -99,7 +99,7 @@ class LoggerMiddlewareTest(BaseTest):
         store_current_request.assert_called_once()
 
         scope = store_current_request.call_args[0][0]
-        self.assertDictContainsSubset(expected_scope, scope)
+        self.assertEqual(scope, {**expected_scope, **scope})
 
     def test_should_return_current_request(self):
         from fastapi import FastAPI

--- a/rollbar/test/fastapi_tests/test_middleware.py
+++ b/rollbar/test/fastapi_tests/test_middleware.py
@@ -302,7 +302,7 @@ class ReporterMiddlewareTest(BaseTest):
         store_current_request.assert_called_once()
 
         scope = store_current_request.call_args[0][0]
-        self.assertDictContainsSubset(expected_scope, scope)
+        self.assertEqual(scope, {**expected_scope, **scope})
 
     @unittest.skipUnless(
         sys.version_info >= (3, 6), 'Global request access is supported in Python 3.6+'

--- a/rollbar/test/fastapi_tests/test_routing.py
+++ b/rollbar/test/fastapi_tests/test_routing.py
@@ -728,7 +728,7 @@ class LoggingRouteTest(BaseTest):
         store_current_request.assert_called_once()
 
         scope = store_current_request.call_args[0][0]
-        self.assertDictContainsSubset(expected_scope, scope)
+        self.assertEqual(scope, {**expected_scope, **scope})
 
     @unittest.skipUnless(
         sys.version_info >= (3, 6), 'Global request access is supported in Python 3.6+'

--- a/rollbar/test/starlette_tests/test_logger.py
+++ b/rollbar/test/starlette_tests/test_logger.py
@@ -96,7 +96,7 @@ class LoggerMiddlewareTest(BaseTest):
         store_current_request.assert_called_once()
 
         scope = store_current_request.call_args[0][0]
-        self.assertDictContainsSubset(expected_scope, scope)
+        self.assertEqual(scope, {**expected_scope, **scope})
 
     def test_should_return_current_request(self):
         from starlette.applications import Starlette

--- a/rollbar/test/starlette_tests/test_middleware.py
+++ b/rollbar/test/starlette_tests/test_middleware.py
@@ -273,7 +273,7 @@ class ReporterMiddlewareTest(BaseTest):
         store_current_request.assert_called_once()
 
         scope = store_current_request.call_args[0][0]
-        self.assertDictContainsSubset(expected_scope, scope)
+        self.assertEqual(scope, {**expected_scope, **scope})
 
     @unittest.skipUnless(
         sys.version_info >= (3, 6), 'Global request access is supported in Python 3.6+'


### PR DESCRIPTION
## Description of the change

This PR adds official support for Python 3.12 and resolves some deprecated methods from unittest.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #453
- Fix #392

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
