### PR TITLE
Changed the `ShortenerTransform` to use breadth first traversal

### DIFF
--- a/rollbar/lib/transform.py
+++ b/rollbar/lib/transform.py
@@ -1,4 +1,6 @@
 class Transform(object):
+    depth_first = True
+
     def default(self, o, key=None):
         return o
 

--- a/rollbar/lib/transforms/__init__.py
+++ b/rollbar/lib/transforms/__init__.py
@@ -89,7 +89,7 @@ def _transform(obj, transform, key=None):
         "allowed_circular_reference_types": _ALLOWED_CIRCULAR_REFERENCE_TYPES,
     }
 
-    return traverse.traverse(obj, key=key, **handlers)
+    return traverse.traverse(obj, key=key, depth_first=transform.depth_first, **handlers)
 
 
 __all__ = ["transform", "Transform"]

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -4,7 +4,7 @@ import itertools
 import reprlib
 
 from collections.abc import Mapping
-from typing import Union
+from typing import Union, Tuple
 
 from rollbar.lib import (
     integer_types, key_in, key_depth, sequence_types,
@@ -26,7 +26,7 @@ _type_name_mapping = {
 }
 
 
-def _max_left_right(max_len: int, seperator_len: int) -> tuple[int, int]:
+def _max_left_right(max_len: int, seperator_len: int) -> Tuple[int, int]:
     left = max(0, (max_len-seperator_len)//2)
     right = max(0, max_len-seperator_len-left)
     return left, right

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -186,7 +186,7 @@ class ShortenerTransform(Transform):
     def default(self, o, key=None):
         if self._should_drop(o, key):
             if isinstance(o, (dict, Mapping)):
-                return dict()
+                return {'...': '...'}
             if isinstance(o, sequence_types):
                 return ['...']
 

--- a/rollbar/test/test_rollbar.py
+++ b/rollbar/test/test_rollbar.py
@@ -1555,7 +1555,7 @@ class RollbarTest(BaseTest):
 
         self.assertEqual(1, len(payload['data']['body']['trace']['frames'][-1]['argspec']))
         self.assertEqual('large', payload['data']['body']['trace']['frames'][-1]['argspec'][0])
-        self.assertEqual("'###############################################...################################################'",
+        self.assertEqual("################################################...#################################################",
                          payload['data']['body']['trace']['frames'][-1]['locals']['large'])
 
     @mock.patch('rollbar.send_payload')
@@ -1586,12 +1586,12 @@ class RollbarTest(BaseTest):
 
         self.assertEqual('large', payload['data']['body']['trace']['frames'][-1]['argspec'][0])
         self.assertTrue(
-            ("['hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', ...]" ==
+            (['hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', '...'] ==
                 payload['data']['body']['trace']['frames'][-1]['argspec'][0])
 
             or
 
-            ("['hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', ...]" ==
+            (['hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', 'hi', '...'] ==
                     payload['data']['body']['trace']['frames'][0]['locals']['xlarge']))
 
 

--- a/rollbar/test/test_shortener_transform.py
+++ b/rollbar/test/test_shortener_transform.py
@@ -202,7 +202,7 @@ class ShortenerTransformTest(BaseTest):
                                         "three": {
                                             "four": {
                                                 "five": {
-                                                    "six": dict(),  # Dropped because it is past the maxlevel.
+                                                    "six": {'...': '...'},  # Dropped because it is past the maxlevel.
                                                     # Shortened
                                                     "ten": "Yep! this should still be here, but it is a litt...long "
                                                            "side, so we might want to cut it down a bit."

--- a/rollbar/test/test_traverse.py
+++ b/rollbar/test/test_traverse.py
@@ -1,3 +1,4 @@
+from rollbar.lib.transform import Transform
 from rollbar.lib.traverse import traverse
 
 from rollbar.test import BaseTest
@@ -19,6 +20,17 @@ class NamedTuple(tuple):
         return [l for l in self._labels if l is not None]
 
 
+class KeyMemTransform(Transform):
+    """
+    A transform that just stores the keys.
+    """
+    keys = []
+
+    def default(self, o, key=None):
+        self.keys.append((key, o))
+        return o
+
+
 class RollbarTraverseTest(BaseTest):
     """
     Objects that appear to be a namedtuple, like SQLAlchemy's KeyedTuple,
@@ -35,3 +47,116 @@ class RollbarTraverseTest(BaseTest):
     def test_bad_object(self):
         setattr(self.tuple, "_fields", "not quite a named tuple")
         self.assertEqual(traverse(self.tuple), (1, 2, 3))
+
+    def test_depth_first(self):
+        obj = {
+            "one": ["four", "five", 6, 7],
+            "two": ("eight", "nine", "ten"),
+            "three": {
+                "eleven": 12,
+                "thirteen": 14
+            }
+        }
+        transform = KeyMemTransform()
+        transform.keys = []
+
+        traverse(
+            obj,
+            key=(),
+            string_handler=transform.default,
+            tuple_handler=transform.default,
+            namedtuple_handler=transform.default,
+            list_handler=transform.default,
+            set_handler=transform.default,
+            mapping_handler=transform.default,
+            path_handler=transform.default,
+            default_handler=transform.default,
+            circular_reference_handler=transform.default,
+            allowed_circular_reference_types=transform.default,
+        )
+
+        self.assertEqual(
+            transform.keys,
+            [
+                (("one", 0), "four"),
+                (("one", 1), "five"),
+                (("one", 2), 6),
+                (("one", 3), 7),
+                (("one",), ["four", "five", 6, 7]),
+                (("two", 0), "eight"),
+                (("two", 1), "nine"),
+                (("two", 2), "ten"),
+                (("two",), ("eight", "nine", "ten")),
+                (("three", "eleven"), 12),
+                (("three", "thirteen"), 14),
+                (("three",), {
+                    "eleven": 12,
+                    "thirteen": 14
+                }),
+                ((), {
+                    "one": ["four", "five", 6, 7],
+                    "two": ("eight", "nine", "ten"),
+                    "three": {
+                        "eleven": 12,
+                        "thirteen": 14
+                    }
+                }),
+            ],
+        )
+
+    def test_breadth_first(self):
+        obj = {
+            "one": ["four", "five", 6, 7],
+            "two": ("eight", "nine", "ten"),
+            "three": {
+                "eleven": 12,
+                "thirteen": 14
+            }
+        }
+        transform = KeyMemTransform()
+        transform.keys = []
+
+        traverse(
+            obj,
+            key=(),
+            string_handler=transform.default,
+            tuple_handler=transform.default,
+            namedtuple_handler=transform.default,
+            list_handler=transform.default,
+            set_handler=transform.default,
+            mapping_handler=transform.default,
+            path_handler=transform.default,
+            default_handler=transform.default,
+            circular_reference_handler=transform.default,
+            allowed_circular_reference_types=transform.default,
+            depth_first=False,
+        )
+
+        self.assertEqual(
+            transform.keys,
+            [
+                ((), {
+                    "one": ["four", "five", 6, 7],
+                    "two": ("eight", "nine", "ten"),
+                    "three": {
+                        "eleven": 12,
+                        "thirteen": 14
+                    }
+                }),
+                (("one",), ["four", "five", 6, 7]),
+                (("one", 0), "four"),
+                (("one", 1), "five"),
+                (("one", 2), 6),
+                (("one", 3), 7),
+                (("two",), ("eight", "nine", "ten")),
+                (("two", 0), "eight"),
+                (("two", 1), "nine"),
+                (("two", 2), "ten"),
+                (("three",), {
+                    "eleven": 12,
+                    "thirteen": 14
+                }),
+                (("three", "eleven"), 12),
+                (("three", "thirteen"), 14),
+            ],
+        )


### PR DESCRIPTION
## Description of the change

This is an additional performance improvement for our data processing and cleaning. We don't want to traverse and shorten deep in a large data structure if we are going to later drop that structure.

By changing to a breadth first traversal for the `ShortenerTransform` we ensure we only traverse data structures we will pass to further transforms.

One change that comes out of this impacts how we pass shortened objects between transforms. The `ShortenerTransform` no longer turns `list` and other built-in types into strings e.g. `'[1, 2, 3, ...]'`. It now returns a list e.g. `[1, 2, 3, '...']`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #329
   *Note: We could further optimize this by limiting our collection of locals prior to traversing the payload body.*

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
