### PR TITLE
logger: Set `allow_logging_basic_config` as `False`

### DIFF
--- a/rollbar/logger.py
+++ b/rollbar/logger.py
@@ -60,7 +60,9 @@ class RollbarHandler(logging.Handler):
 
         if access_token is not None:
             rollbar.init(
-                access_token, environment, **resolve_logging_types(kw))
+                access_token, environment,
+                allow_logging_basic_config=False,   # a handler shouldn't configure the root logger
+                **resolve_logging_types(kw))
 
         self.notify_level = _checkLevel(level)
 


### PR DESCRIPTION
## Description of the change
A handler shouldn't configure the root logger. This was really unexpected.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
