### PR TITLE
Fixed #465 httpx 0.28.0 not compatible with rollbar v1.

### DIFF
--- a/rollbar/lib/_async.py
+++ b/rollbar/lib/_async.py
@@ -132,10 +132,16 @@ async def _post_api_httpx(path, payload_str, access_token=None):
         'proxy_password': rollbar.SETTINGS.get('http_proxy_password'),
     }
     proxies = transport._get_proxy_cfg(proxy_cfg)
+    mounts = None
+    if proxies:
+        mounts = {
+            'http://': httpx.HTTPTransport(proxy=proxies['http']),
+            'https://': httpx.HTTPTransport(proxy=proxies['https']),
+        }
 
     url = urljoin(rollbar.SETTINGS['endpoint'], path)
     async with httpx.AsyncClient(
-        proxies=proxies, verify=rollbar.SETTINGS.get('verify_https', True)
+        mounts=mounts, verify=rollbar.SETTINGS.get('verify_https', True)
     ) as client:
         resp = await client.post(
             url,

--- a/rollbar/lib/transport.py
+++ b/rollbar/lib/transport.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import requests
 import threading
 
@@ -12,19 +14,19 @@ def _session():
     return _local.session
 
 
-def _get_proxy_cfg(kw):
+def _get_proxy_cfg(kw: dict) -> Optional[dict]:
     proxy = kw.pop('proxy', None)
     proxy_user = kw.pop('proxy_user', None)
     proxy_password = kw.pop('proxy_password', None)
     if proxy and proxy_user and proxy_password:
         return {
-            'http': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
-            'https': 'http://{}:{}@{}'.format(proxy_user, proxy_password, proxy),
+            'http': f'http://{proxy_user}:{proxy_password}@{proxy}',
+            'https': f'http://{proxy_user}:{proxy_password}@{proxy}',
         }
     elif proxy:
         return {
-            'http': 'http://{}'.format(proxy),
-            'https': 'http://{}'.format(proxy),
+            'http': f'http://{proxy}',
+            'https': f'http://{proxy}',
         }
 
 

--- a/rollbar/test/test_lib.py
+++ b/rollbar/test/test_lib.py
@@ -1,4 +1,5 @@
 from rollbar.lib import dict_merge, prefix_match, key_match, key_depth
+from rollbar.lib.transport import _get_proxy_cfg
 
 from rollbar.test import BaseTest
 
@@ -108,3 +109,19 @@ class RollbarLibTest(BaseTest):
         self.assertEqual(42, result['a']['b'])
         self.assertIn('y', result['a'])
         self.assertRegex(result['a']['y'], r'Uncopyable obj')
+
+    def test_transport_get_proxy_cfg(self):
+        result = _get_proxy_cfg({})
+        self.assertEqual(None, result)
+
+        result = _get_proxy_cfg({'proxy': 'localhost'})
+        self.assertEqual({'http': 'http://localhost', 'https': 'http://localhost'}, result)
+
+        result = _get_proxy_cfg({'proxy': 'localhost:8080'})
+        self.assertEqual({'http': 'http://localhost:8080', 'https': 'http://localhost:8080'}, result)
+
+        result = _get_proxy_cfg({'proxy': 'localhost', 'proxy_user': 'username', 'proxy_password': 'password'})
+        self.assertEqual({
+            'http': 'http://username:password@localhost',
+            'https': 'http://username:password@localhost',
+        }, result)


### PR DESCRIPTION
## Description of the change

This fixes the proxies issue with the latest release of httpx 0.28.0.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #465 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
