### PR TITLE
Added support for custom payload transforms

### DIFF
--- a/rollbar/lib/transform.py
+++ b/rollbar/lib/transform.py
@@ -1,5 +1,6 @@
 class Transform(object):
     depth_first = True
+    priority = 100
 
     def default(self, o, key=None):
         return o

--- a/rollbar/lib/transforms/scrub.py
+++ b/rollbar/lib/transforms/scrub.py
@@ -6,6 +6,7 @@ from rollbar.lib.transform import Transform
 
 class ScrubTransform(Transform):
     suffix_matcher = None
+    priority = 40
     def __init__(self, suffixes=None, redact_char='*', randomize_len=True):
         super(ScrubTransform, self).__init__()
         if suffixes is not None and len(suffixes) > 0:

--- a/rollbar/lib/transforms/scrub_redact.py
+++ b/rollbar/lib/transforms/scrub_redact.py
@@ -9,6 +9,7 @@ REDACT_REF = RedactRef()
 
 
 class ScrubRedactTransform(ScrubTransform):
+    priority = 20
     def default(self, o, key=None):
         if o is REDACT_REF:
             return self.redact(o)

--- a/rollbar/lib/transforms/scruburl.py
+++ b/rollbar/lib/transforms/scruburl.py
@@ -9,6 +9,7 @@ _starts_with_auth_re = re.compile(r'^[a-zA-Z0-9-_]*(:[^@/]+)?@')
 
 
 class ScrubUrlTransform(ScrubTransform):
+    priority = 50
     def __init__(self,
                  suffixes=None,
                  scrub_username=False,

--- a/rollbar/lib/transforms/serializable.py
+++ b/rollbar/lib/transforms/serializable.py
@@ -9,6 +9,7 @@ from rollbar.lib.transform import Transform
 
 
 class SerializableTransform(Transform):
+    priority = 30
     def __init__(self, safe_repr=True, safelist_types=None):
         super(SerializableTransform, self).__init__()
         self.safe_repr = safe_repr

--- a/rollbar/lib/transforms/shortener.py
+++ b/rollbar/lib/transforms/shortener.py
@@ -108,6 +108,7 @@ def shorten_tuple(obj: tuple, max_len: int) -> tuple:
 
 class ShortenerTransform(Transform):
     depth_first = False
+    priority = 10
 
     def __init__(self, safe_repr=True, keys=None, **sizes):
         super(ShortenerTransform, self).__init__()

--- a/rollbar/test/test_transform.py
+++ b/rollbar/test/test_transform.py
@@ -1,0 +1,93 @@
+import copy
+
+import rollbar
+from rollbar.test import BaseTest
+from rollbar.lib.transforms import Transform
+from rollbar.lib.transforms.shortener import ShortenerTransform
+from rollbar.lib.transforms.scrub_redact import ScrubRedactTransform
+from rollbar.lib.transforms.serializable import SerializableTransform
+from rollbar.lib.transforms.scrub import ScrubTransform
+from rollbar.lib.transforms.scruburl import ScrubUrlTransform
+
+_test_access_token = 'aaaabbbbccccddddeeeeffff00001111'
+_default_settings = copy.deepcopy(rollbar.SETTINGS)
+
+
+class TransformTest(BaseTest):
+    def setUp(self):
+        rollbar._initialized = False
+        rollbar.SETTINGS = copy.deepcopy(_default_settings)
+        rollbar.init(_test_access_token, locals={'enabled': True}, handler='blocking', timeout=12345)
+
+    def test_default_transforms(self):
+        transforms = {transform.__class__ for transform in rollbar._transforms}
+
+        self.assertEqual({
+            ShortenerTransform,
+            ScrubRedactTransform,
+            SerializableTransform,
+            ScrubTransform,
+            ScrubUrlTransform,
+        }, transforms)
+
+    def test_add_custom_transform(self):
+        class CustomTransform(Transform):
+            pass
+
+        rollbar._initialized = False
+        rollbar.SETTINGS = copy.deepcopy(_default_settings)
+        rollbar.init(_test_access_token,
+                     locals={'enabled': True},
+                     handler='blocking',
+                     timeout=12345,
+                     custom_transforms=[CustomTransform()])
+
+        transforms = {transform.__class__ for transform in rollbar._transforms}
+        transforms_ordered = [transform.__class__ for transform in rollbar._transforms]
+
+        self.assertEqual({
+            ShortenerTransform,
+            ScrubRedactTransform,
+            SerializableTransform,
+            ScrubTransform,
+            ScrubUrlTransform,
+            CustomTransform,
+        }, transforms)
+
+        # CustomTransform should be last because it has the default priority of 100
+        self.assertEqual([
+            ShortenerTransform,
+            ScrubRedactTransform,
+            SerializableTransform,
+            ScrubTransform,
+            ScrubUrlTransform,
+            CustomTransform,
+        ], transforms_ordered)
+
+    def test_add_custom_transform_first(self):
+        class CustomTransform(Transform):
+            priority = 1
+
+        class CustomTransformTwo(Transform):
+            priority = 35
+
+        rollbar._initialized = False
+        rollbar.SETTINGS = copy.deepcopy(_default_settings)
+        rollbar.init(_test_access_token,
+                     locals={'enabled': True},
+                     handler='blocking',
+                     timeout=12345,
+                     custom_transforms=[CustomTransform(), CustomTransformTwo()])
+
+        transforms = [transform.__class__ for transform in rollbar._transforms]
+
+        # Custom transforms should be first and fifth.
+        self.assertEqual([
+            CustomTransform,  # priority 1
+            ShortenerTransform,  # priority 10
+            ScrubRedactTransform,  # priority 20
+            SerializableTransform,  # priority 30
+            CustomTransformTwo,  # priority 35
+            ScrubTransform,  # priority 40
+            ScrubUrlTransform,  # priority 50
+        ], transforms)


### PR DESCRIPTION
## Description of the change

This PR adds support for custom transforms. It also specifies how transforms are ordered based on a priority attribute. It retains the current transform order but now allows a user to insert a custom transform at any point in the transform stack.

A custom transform could look something like this:

```py
import rollbar
from rollbar.lib.transforms import Transform

class MyTransform(Transform):
    # A lower priority is value is sooner.
    # Built-in transforms are set at 10, 20, 30, 40, and 50.
    # With a priority of 100, this will run last.
    priority = 100

    # This method will be called for each item in the payload. 
    # See rollbar.lib.transforms.Transform for specific methods for most types.
    def default(self, o, key=None):
        return o


# custom_transforms should be a list of Transform objects.
rollbar.init('<my secret key>', 
             custom_transforms=[MyTransform()])
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #245

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
