### PR TITLE
Restore build for pyramid and cli entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
 version = {attr = "rollbar.__version__"}
+
+[project.scripts]
+rollbar = "rollbar.cli:main"
+
+[project.entry-points."paste.filter_app_factory"]
+pyramid = "rollbar.contrib.pyramid:create_rollbar_middleware"


### PR DESCRIPTION
## Description of the change

The build for the entrypoints for pyramid and the rollbar cli were removed in the move from setup.py to pyproject.toml in https://github.com/rollbar/pyrollbar/pull/455 . This PR adds them to pyproject.toml.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

n/a

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
