### PR TITLE
add custom data to the correct payload key

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -508,7 +508,7 @@ def report_message(message, level='error', request=None, extra_data=None, payloa
     message: the string body of the message
     level: level to report at. One of: 'critical', 'error', 'warning', 'info', 'debug'
     request: the request object for the context of the message
-    extra_data: dictionary of params to include with the message. 'body' is reserved.
+    extra_data: optional, will be included in the 'custom' section of the payload
     payload_data: param names to pass in the 'data' level of the payload; overrides defaults.
     """
     try:
@@ -862,7 +862,7 @@ def _report_message(message, level, request, extra_data, payload_data):
 
     if extra_data:
         extra_data = extra_data
-        data['body']['message'].update(extra_data)
+        data['custom'] = extra_data
 
     request = _get_actual_request(request)
     _add_request_data(data, request)

--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -862,6 +862,7 @@ def _report_message(message, level, request, extra_data, payload_data):
 
     if extra_data:
         extra_data = extra_data
+        data['body']['message'].update(extra_data)
         data['custom'] = extra_data
 
     request = _get_actual_request(request)

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -46,6 +46,8 @@ class LogHandlerTest(BaseTest):
         payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['data']['body']['message']['body'], "Hello 1 world")
+        self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
+        self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
         self.assertEqual(payload['data']['custom']['args'], (1, 'world'))
         self.assertEqual(payload['data']['custom']['record']['name'], __name__)
 

--- a/rollbar/test/test_loghandler.py
+++ b/rollbar/test/test_loghandler.py
@@ -46,8 +46,8 @@ class LogHandlerTest(BaseTest):
         payload = send_payload.call_args[0][0]
 
         self.assertEqual(payload['data']['body']['message']['body'], "Hello 1 world")
-        self.assertEqual(payload['data']['body']['message']['args'], (1, 'world'))
-        self.assertEqual(payload['data']['body']['message']['record']['name'], __name__)
+        self.assertEqual(payload['data']['custom']['args'], (1, 'world'))
+        self.assertEqual(payload['data']['custom']['record']['name'], __name__)
 
     @mock.patch('rollbar.send_payload')
     def test_string_or_int_level(self, send_payload):


### PR DESCRIPTION
## Description of the change

The PR writes `extra_data` to the `custom` key of the payload as specified in the payload schema: https://docs.rollbar.com/reference/create-item

Pyrollbar exception payloads already do this correctly, and the change only affects message payloads. The impact of the current bug is that the custom data is discarded in the pipeline, doesn't get stored or indexed with the occurrence, and therefore cannot be searched.

This PR treats the change as non-breaking, since the custom data can currently only be found in the raw json of the occurrence, and is discarded everywhere else. One example where this is used is the "Params" section of the item detail page in the Rollbar app. After this change, the custom data would still be visible there, but with key names consistent with other items.

If we do consider this a breaking change and want to avoid that, the PR can be updated to write the data in both places, with the tradeoff of a larger payload.

**Update:**
Updated to preserve the previous location, to be on the side of caution re. the breaking behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached

