### PR TITLE
Fixed SDK-426 scrubbing for namedtuples

### DIFF
--- a/rollbar/test/test_scrub_redact_transform.py
+++ b/rollbar/test/test_scrub_redact_transform.py
@@ -58,12 +58,19 @@ class ScrubRedactTransformTest(BaseTest):
         expected = set([SCRUBBED, NOT_REDACT_REF])
         self._assertScrubbed(obj, expected)
 
-    def scrub_tuple(self):
+    def test_scrub_tuple(self):
         obj = (REDACT_REF, REDACT_REF, REDACT_REF)
         expected = (SCRUBBED, SCRUBBED, SCRUBBED)
         self._assertScrubbed(obj, expected)
 
+    def test_scrub_namedtuple(self):
+        from collections import namedtuple
+        TestNamedTuple = namedtuple('TestNamedTuple', ['scrub_me', 'dont_scrub_me'])
+        obj = TestNamedTuple(scrub_me=REDACT_REF, dont_scrub_me=NOT_REDACT_REF)
+        expected = TestNamedTuple(scrub_me=SCRUBBED, dont_scrub_me=NOT_REDACT_REF)
+        self._assertScrubbed(obj, expected)
+
     def test_scrub_dict(self):
-        obj = {'scrub_me': REDACT_REF}
-        expected = {'scrub_me': SCRUBBED}
+        obj = {'scrub_me': REDACT_REF, 'dont_scrub_me': NOT_REDACT_REF}
+        expected = {'scrub_me': SCRUBBED, 'dont_scrub_me': NOT_REDACT_REF}
         self._assertScrubbed(obj, expected)

--- a/rollbar/test/test_scrub_transform.py
+++ b/rollbar/test/test_scrub_transform.py
@@ -61,6 +61,20 @@ class ScrubTransformTest(BaseTest):
         expected = dict(obj)
         self._assertScrubbed([], obj, expected)
 
+    def test_scrub_named_tuple(self):
+        from collections import namedtuple
+        Obj = namedtuple('obj', ['hello', 'password'])
+        obj = Obj('world', 'cleartext')
+        expected = Obj('world', '*********')
+        self._assertScrubbed([['password']], obj, expected)
+
+    def test_scrub_named_tuple_in_list(self):
+        from collections import namedtuple
+        Obj = namedtuple('obj', ['hello', 'password'])
+        obj = [Obj('world', 'cleartext'), 'another element']
+        expected = [Obj('world', '*********'), 'another element']
+        self._assertScrubbed([['password']], obj, expected)
+
     def test_scrub_simple_dict(self):
         obj = {'hello': 'world', 'password': 'cleartext'}
         expected = copy.deepcopy(obj)

--- a/rollbar/test/test_transform.py
+++ b/rollbar/test/test_transform.py
@@ -26,7 +26,6 @@ class TransformTest(BaseTest):
             ShortenerTransform,
             ScrubRedactTransform,
             SerializableTransform,
-            ScrubTransform,
             ScrubUrlTransform,
         }, transforms)
 
@@ -49,7 +48,6 @@ class TransformTest(BaseTest):
             ShortenerTransform,
             ScrubRedactTransform,
             SerializableTransform,
-            ScrubTransform,
             ScrubUrlTransform,
             CustomTransform,
         }, transforms)
@@ -59,7 +57,6 @@ class TransformTest(BaseTest):
             ShortenerTransform,
             ScrubRedactTransform,
             SerializableTransform,
-            ScrubTransform,
             ScrubUrlTransform,
             CustomTransform,
         ], transforms_ordered)
@@ -88,6 +85,5 @@ class TransformTest(BaseTest):
             ScrubRedactTransform,  # priority 20
             SerializableTransform,  # priority 30
             CustomTransformTwo,  # priority 35
-            ScrubTransform,  # priority 40
             ScrubUrlTransform,  # priority 50
         ], transforms)


### PR DESCRIPTION
## Description of the change

This change fixes an issue where named tuple fields included in `scrub_fields` were not being scrubbed/redacted before the namedtuple was serialized.

This was caused by the `_serialize_frame_data()` method running `ScrubRedactTransform()` without checking the `scrub_fields` values before serializng the namedtuple. As a result by the time we came to scrub the namedtuple with the `scrub_fields` values had been serialized to a string.

This PR creates an instance of `ScrubRedactTransform` during `init()` that is passed the `scrub_fields` and used during both `_serialize_frame_data()` and `_transform()`.

While makeing that change I noticed that `ScrubRedactTransform` can further do the work of `ScrubTransform` if it is passed the same arguments during initialization. Because of that I removed `ScrubTransform` from the list of transforms since `ScrubRedactTransform` will do both now. This futher reduces the total number of traversals and transforms we need to do of the data, making it more efficient.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix: SDK-426

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
