### PR TITLE
Updated tested frameworks and dropped Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
             python-version: 3.9
 
           # FastAPI
-          - framework: FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
+          - framework: FASTAPI_VERSION=0.110.3 httpx==0.24.1 python-multipart==0.0.9
             python-version: 3.7
-          - framework: FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
+          - framework: FASTAPI_VERSION=0.110.3 httpx==0.24.1 python-multipart==0.0.9
             python-version: 3.13
           - framework: FASTAPI_VERSION=0.115.11 httpx==0.27.0 python-multipart==0.0.9
             python-version: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
           # Flask
           - framework: FLASK_VERSION=2.3.3
             python-version: 3.7
-          - framework: FLASK_VERSION=3.0.3
+          - framework: FLASK_VERSION=3.1.0
             python-version: 3.7
+          - framework: FLASK_VERSION=3.1.0
+            python-version: 3.8
 
           # Django
           - framework: DJANGO_VERSION=4.2.20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,13 @@ jobs:
           - NONE
           - FLASK_VERSION=1.1.4
           - FLASK_VERSION=2.3.3
-          - FLASK_VERSION=3.0.3
-          - DJANGO_VERSION=3.2.25
-          - DJANGO_VERSION=4.2.15
-          - DJANGO_VERSION=5.0.8
+          - FLASK_VERSION=3.1.0
+          - DJANGO_VERSION=4.2.20
+          - DJANGO_VERSION=5.1.7
           - PYRAMID_VERSION=1.10.8
           - PYRAMID_VERSION=2.0.2
-          - FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9
-          - FASTAPI_VERSION=0.112.1 httpx==0.27.0 python-multipart==0.0.9
+          - FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
+          - FASTAPI_VERSION=0.115.11 httpx==0.27.0 python-multipart==0.0.9
         exclude:
           # Test frameworks on the python versions they support, according to pypi registry
           # Flask
@@ -34,23 +33,23 @@ jobs:
             python-version: 3.7
 
           # Django
-          - framework: DJANGO_VERSION=3.2.25
-            python-version: 3.11
-          - framework: DJANGO_VERSION=3.2.25
-            python-version: 3.12
-          - framework: DJANGO_VERSION=4.2.15
+          - framework: DJANGO_VERSION=4.2.20
             python-version: 3.7
-          - framework: DJANGO_VERSION=5.0.8
+          - framework: DJANGO_VERSION=4.2.20
+            python-version: 3.13
+          - framework: DJANGO_VERSION=5.1.7
             python-version: 3.7
-          - framework: DJANGO_VERSION=5.0.8
+          - framework: DJANGO_VERSION=5.1.7
             python-version: 3.8
-          - framework: DJANGO_VERSION=5.0.8
+          - framework: DJANGO_VERSION=5.1.7
             python-version: 3.9
 
           # FastAPI
-          - framework: FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9
+          - framework: FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
             python-version: 3.7
-          - framework: FASTAPI_VERSION=0.112.1 httpx==0.27.0 python-multipart==0.0.9
+          - framework: FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
+            python-version: 3.13
+          - framework: FASTAPI_VERSION=0.115.11 httpx==0.27.0 python-multipart==0.0.9
             python-version: 3.7
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - DJANGO_VERSION=5.1.7
           - PYRAMID_VERSION=1.10.8
           - PYRAMID_VERSION=2.0.2
-          - FASTAPI_VERSION=0.110.0 httpx==0.24.1 python-multipart==0.0.9
+          - FASTAPI_VERSION=0.110.3 httpx==0.24.1 python-multipart==0.0.9
           - FASTAPI_VERSION=0.115.11 httpx==0.27.0 python-multipart==0.0.9
         exclude:
           # Test frameworks on the python versions they support, according to pypi registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,8 @@ jobs:
           - DJANGO_VERSION=3.2.25
           - DJANGO_VERSION=4.2.15
           - DJANGO_VERSION=5.0.8
-          - TWISTED_VERSION=20.3.0
-          - TWISTED_VERSION=21.7.0
-          - TWISTED_VERSION=22.10.0
           - PYRAMID_VERSION=1.10.8
           - PYRAMID_VERSION=2.0.2
-          - STARLETTE_VERSION=0.30.0 httpx==0.24.1 python-multipart==0.0.9
-          - STARLETTE_VERSION=0.38.2 httpx==0.27.0 python-multipart==0.0.9
           - FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9
           - FASTAPI_VERSION=0.112.1 httpx==0.27.0 python-multipart==0.0.9
         exclude:
@@ -59,26 +54,6 @@ jobs:
             python-version: 3.8
           - framework: DJANGO_VERSION=5.0.8
             python-version: 3.9
-
-          # Twisted
-          - framework: TWISTED_VERSION=20.3.0
-            python-version: 3.11
-          - framework: TWISTED_VERSION=20.3.0
-            python-version: 3.12
-          - framework: TWISTED_VERSION=20.3.0
-            python-version: 3.13
-          - framework: TWISTED_VERSION=22.10.0
-            python-version: 3.6
-
-          # Starlette
-          - framework: STARLETTE_VERSION=0.30.0 httpx==0.24.1 python-multipart==0.0.9
-            python-version: 3.6
-          - framework: STARLETTE_VERSION=0.30.0 httpx==0.24.1 python-multipart==0.0.9
-            python-version: 3.7
-          - framework: STARLETTE_VERSION=0.38.2 httpx==0.27.0 python-multipart==0.0.9
-            python-version: 3.6
-          - framework: STARLETTE_VERSION=0.38.2 httpx==0.27.0 python-multipart==0.0.9
-            python-version: 3.7
 
           # FastAPI
           - framework: FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13]
         framework:
           - NONE
           - FLASK_VERSION=1.1.4
@@ -29,11 +29,7 @@ jobs:
           # Test frameworks on the python versions they support, according to pypi registry
           # Flask
           - framework: FLASK_VERSION=2.3.3
-            python-version: 3.6
-          - framework: FLASK_VERSION=2.3.3
             python-version: 3.7
-          - framework: FLASK_VERSION=3.0.3
-            python-version: 3.6
           - framework: FLASK_VERSION=3.0.3
             python-version: 3.7
 
@@ -43,11 +39,7 @@ jobs:
           - framework: DJANGO_VERSION=3.2.25
             python-version: 3.12
           - framework: DJANGO_VERSION=4.2.15
-            python-version: 3.6
-          - framework: DJANGO_VERSION=4.2.15
             python-version: 3.7
-          - framework: DJANGO_VERSION=5.0.8
-            python-version: 3.6
           - framework: DJANGO_VERSION=5.0.8
             python-version: 3.7
           - framework: DJANGO_VERSION=5.0.8
@@ -57,11 +49,7 @@ jobs:
 
           # FastAPI
           - framework: FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9
-            python-version: 3.6
-          - framework: FASTAPI_VERSION=0.101.1 httpx==0.24.1 python-multipart==0.0.9
             python-version: 3.7
-          - framework: FASTAPI_VERSION=0.112.1 httpx==0.27.0 python-multipart==0.0.9
-            python-version: 3.6
           - framework: FASTAPI_VERSION=0.112.1 httpx==0.27.0 python-multipart==0.0.9
             python-version: 3.7
 
@@ -77,11 +65,6 @@ jobs:
 
       - name: Install Python Test dependencies
         run: pip install requests webob blinker httpx
-
-      - name: Install Python 3.6 dependencies
-        if: ${{ contains(matrix.python-version, '3.6') }}
-        # typing-extensions dropped support for Python 3.6 in version 4.2
-        run: pip install "typing-extensions<4.2" requests==2.27.0 blinker==1.5 immutables==0.19 webob blinker httpx aiocontextvars
 
       - name: Install Python 3.7 dependencies
         if: ${{ contains(matrix.python-version, '3.7') }}

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Generally, PyRollbar can be used with any Python framework. However, we have off
 | Framework | Support Duration           | Tested Versions |
 |-----------|----------------------------|-----------------|
 | Celery    | Release +1 year            | None            |
-| Django    | Release or LTS end +1 year | 3.2, 4.2, 5.0   |
-| FastAPI   | Release +1 year            | 0.101, 0.112    |
-| Flask     | Release +1 year            | 1.1, 2.3, 3.0   |
+| Django    | Release or LTS end +1 year | 4.2, 5.1        |
+| FastAPI   | Release +1 year            | 0.110, 0.115    |
+| Flask     | Release +1 year            | 1.1, 2.3, 3.1   |
 | Pyramid   | Release +1 year            | 1.10, 2.0       |
 
 Official support means that we ship and maintain integrations for these frameworks. It also means that we test against these frameworks as part of our CI pipeline.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python notifier for reporting exceptions, errors, and log messages to [Rollbar](
 
 | PyRollbar Version | Python Version Compatibility                  | Support Level       |
 |-------------------|-----------------------------------------------|---------------------|
-| 1.1.0             | 3.6, 3.7. 3.8, 3.9, 3.10, 3.11, 3.12          | Full                |
+| 1.3.0             | 3.7. 3.8, 3.9, 3.10, 3.11, 3.12, 3.13         | Full                |
 | 0.16.3            | 2.7, 3.4, 3.5, 3.6, 3.7. 3.8, 3.9, 3.10, 3.11 | Security Fixes Only |
 
 #### Support Level Definitions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ maintainers = [{name = "Rollbar, Inc.", email = "support@rollbar.com"}]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: System :: Logging",
     "Topic :: System :: Monitoring",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "requests>=0.12.1",
 ]


### PR DESCRIPTION
## Description of the change

This PR updates our testing matrix for supported framework versions. It also removes support for Python 3.6, and adds 3.13 support in all the appropriate places.

We had some CI tests for frameworks we no longer officially support. This removes them from our CI matrix.

## Type of change

- [x] Maintenance

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
