### PR TITLE
Allow disabling payload logging on non-200 status

### DIFF
--- a/rollbar/__init__.py
+++ b/rollbar/__init__.py
@@ -316,6 +316,7 @@ SETTINGS = {
     'capture_username': False,
     'capture_ip': True,
     'log_all_rate_limited_items': True,
+    'log_payload_on_error': True,
     'http_proxy': None,
     'http_proxy_user': None,
     'http_proxy_password': None,
@@ -1730,7 +1731,9 @@ def _parse_response(path, access_token, params, resp, endpoint=None):
 
     if resp.status_code == 429:
         if SETTINGS['log_all_rate_limited_items'] or not last_response_was_429:
-            log.warning("Rollbar: over rate limit, data was dropped. Payload was: %r", params)
+            log.warning("Rollbar: over rate limit, data was dropped.")
+            if SETTINGS['log_payload_on_error']:
+                log.warning("Payload was: %r", params)
         return
     elif resp.status_code == 502:
         log.exception('Rollbar api returned a 502')
@@ -1743,7 +1746,9 @@ def _parse_response(path, access_token, params, resp, endpoint=None):
             payload = json.loads(params)
             uuid = payload['data']['uuid']
             host = payload['data']['server']['host']
-            log.error("Rollbar: request entity too large for UUID %r\n. Payload:\n%r", uuid, payload)
+            log.error("Rollbar: request entity too large for UUID %r\n.", uuid)
+            if SETTINGS['log_payload_on_error']:
+                log.error("Payload:\n%r", payload)
         except (TypeError, ValueError):
             log.exception('Unable to decode JSON for failsafe.')
         except KeyError:


### PR DESCRIPTION
## Description of the change

#486
Added "log_payload_on_error" setting, to have ability to not log payloads even in case of non-200 codes received from the host. This addresses potential security issue of exposing access token in logs, as well as allows to not spam huge payloads locally.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

#486

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
