### PR TITLE
Fix broken test command in contributing section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,9 @@ For bug reports, please [open an issue on GitHub](https://github.com/rollbar/pyr
 4. Push to the branch (```git push origin my-new-feature```)
 5. Create new Pull Request
 
-Tests are in `rollbar/test`. To run the tests: `python setup.py test`
+Tests are in `rollbar/test`. To run the tests, install the test dependencies and run pytest:
+
+    pip install -e '.[test]'   # or: uv sync --group test
+    pytest
+
+To run against all supported Python versions, use `tox`.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ For bug reports, please [open an issue on GitHub](https://github.com/rollbar/pyr
 4. Push to the branch (```git push origin my-new-feature```)
 5. Create new Pull Request
 
-Tests are in `rollbar/test`. To run the tests, install the test dependencies and run pytest:
+Tests are in `rollbar/test`. To run them:
 
-    pip install -e '.[test]'   # or: uv sync --group test
+    pip install -e . --group test
     pytest
-
-To run against all supported Python versions, use `tox`.


### PR DESCRIPTION
Hey all.

Confirmed, there's no `[project.optional-dependencies]` here, so .[test] resolves to nothing and pip just warns the extra is missing. Switched to `pip install -e . `--group test`. Worth noting `--group` needs `pip ≥ 25.1` (when PEP 735 landed), so I added a `uv sync --group test` fallback in the doc for anyone on older pip. 
